### PR TITLE
Switched all structlogs/prints to stdlib logger

### DIFF
--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -18,14 +18,15 @@ import sys
 import time
 
 from . import cli, config, tpc_info, util
+from .log import log
 
 total_start = time.perf_counter()
 
 
 def finish():
     total_time = time.perf_counter() - total_start
-    print("Done.")
-    util.debug_print(f"Full process took {total_time:0.2f} s")
+    log.info("Done.")
+    log.debug(f"Full process took {total_time:0.2f} s")
     sys.exit(0)
 
 
@@ -37,16 +38,17 @@ local_cache_location = pathlib.Path(
 
 def main():
     (dataset_info, argument_info) = cli.parse_args_and_get_dataset_info()
-    print(
-        f"Creating an instance of Dataset '{argument_info.dataset}' in '{argument_info.format}' format..."
+    log.info(
+        f"Creating an instance of Dataset '{argument_info.dataset}' in "
+        f"'{argument_info.format}' format..."
     )
     # Here could be a check for whether this dataset instance already exists.
-    # However, because it may be possible that it was generated using different parameters
-    # we skip it for now. It will be in the cache so the penalty for re-creating it
-    # is small. In the future, we could inquire the metadata file to check if an existing
-    # dataset is still valid.
+    # However, because it may be possible that it was generated using different
+    # parameters, we skip it for now. It will be in the cache so the penalty for
+    # re-creating it is small. In the future, we could inquire the metadata file to
+    # check if an existing dataset is still valid.
 
-    util.debug_print(f"Checking local cache at {local_cache_location}")
+    log.debug(f"Checking local cache at {local_cache_location}")
     cached_dataset_path = pathlib.Path(
         local_cache_location,
         argument_info.dataset,
@@ -58,13 +60,13 @@ def main():
         cached_dataset_path, config.metadata_filename
     )
     if cached_dataset_metadata_file.exists():
-        util.debug_print(
+        log.debug(
             f"Found cached dataset metadata file at '{cached_dataset_metadata_file}'"
         )
         util.copy_from_cache(cached_dataset_path, argument_info.dataset)
         finish()
     else:  # not found in cache, check if the cache has other formats of this dataset
-        util.debug_print(
+        log.debug(
             f"No cached data metadata file found at '{cached_dataset_metadata_file}'"
         )
         for cached_file_format in [x for x in config.supported_formats]:
@@ -75,8 +77,9 @@ def main():
                 cached_file_format,
             )
             if other_format_path.exists():
-                util.debug_print(
-                    f"Found cached instance(s) with a different format/partitioning at '{other_format_path}'"
+                log.debug(
+                    "Found cached instance(s) with a different format/partitioning at "
+                    f"'{other_format_path}'"
                 )
                 # Find a partitioning (any, really, we're going to convert it anyway)
                 subfolders = [
@@ -88,10 +91,11 @@ def main():
                         other_nrows_path, config.metadata_filename
                     )
                     if cached_dataset_metadata_file.exists():
-                        util.debug_print(
-                            f"Found cached dataset in different format/partitioning at '{other_nrows_path}'"
+                        log.debug(
+                            "Found cached dataset in different format/partitioning at "
+                            f"'{other_nrows_path}'"
                         )
-                        util.debug_print(
+                        log.debug(
                             f"Metadata file located at '{cached_dataset_metadata_file}'"
                         )
                         cached_dataset_path = util.convert_dataset(
@@ -106,12 +110,14 @@ def main():
                         util.copy_from_cache(cached_dataset_path, argument_info.dataset)
                         finish()
                     else:
-                        print("Found cached dataset without metadata file, cleaning...")
+                        log.info(
+                            "Found cached dataset without metadata file, cleaning..."
+                        )
                         util.clean_cache_dir(other_nrows_path)
 
     # If we have not exited at this point, nothing useable was found in the local cache.
     # We need to either generate or download the data.
-    print("Dataset not found in local cache.")
+    log.info("Dataset not found in local cache.")
 
     if argument_info.dataset in tpc_info.tpc_datasets:
         cached_dataset_path = util.generate_dataset(

--- a/datalogistik/log.py
+++ b/datalogistik/log.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2022, Voltron Data.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from .config import debug

--- a/datalogistik/log.py
+++ b/datalogistik/log.py
@@ -1,0 +1,9 @@
+import logging
+
+from .config import debug
+
+logging.basicConfig(
+    format="%(levelname)s [%(asctime)s] %(message)s",
+    level=logging.DEBUG if debug else logging.INFO,
+)
+log = logging.getLogger(__name__)

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,17 +8,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "black"
@@ -302,27 +302,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
-name = "structlog"
-version = "21.5.0"
-description = "Structured Logging for Python"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-dev = ["pre-commit", "rich", "cogapp", "tomli", "coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio", "pytest (>=6.0)", "simplejson", "furo", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
-tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio", "pytest (>=6.0)", "simplejson"]
-
-[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -348,7 +327,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.10"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -361,26 +340,25 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.15.1"
+version = "20.16.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 platformdirs = ">=2,<3"
-six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "94c31c1c2d46963d7eeb6036ca7f639eef42cca9e3819132e808da0e4c15b5db"
+content-hash = "48ed10df3a259397635cac12a0aac0e6c09c130b4938c405aa25c05efdcaf51c"
 
 [metadata.files]
 atomicwrites = []
@@ -411,8 +389,6 @@ pyflakes = []
 pyparsing = []
 pytest = []
 pyyaml = []
-six = []
-structlog = []
 toml = []
 tomli = []
 typing-extensions = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ include = ["repo.json"]
 [tool.poetry.dependencies]
 python = "^3.8"
 pyarrow = "^7.0.0"
-structlog = "^21.5.0"
 urllib3 = "^1.26.9"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This PR switches all print statements to the standard library logger, and removes the structlog dependency. It standardizes how we handle logging in the package. Fixes #7 