### PR TITLE
Added a builder for `dsdgen`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -91,7 +91,6 @@ jobs:
           path: dist
   test-convert-without-repo:
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -124,7 +123,6 @@ jobs:
         run: datalogistik -d type_floats -f parquet
   test-tpc-integration:
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -106,9 +106,6 @@ jobs:
     needs: build-wheel
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Add msbuild to PATH
-        if: matrix.os == 'windows-latest'
-        uses: microsoft/setup-msbuild@v1.1
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install pipx
@@ -122,7 +119,32 @@ jobs:
         with:
           name: poetry-build-artifacts
       - name: Install package
-        shell: bash
-        run: ${{ matrix.installer }} install "${{ matrix.installee }}"
+        run: ${{ matrix.installer }} install '${{ matrix.installee }}'
       - name: Test generating and converting a dataset
-        run: datalogistik -d tpc-h -f parquet
+        run: datalogistik -d type_floats -f parquet
+  test-tpc-integration:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        dataset:
+          - tpc-h
+          - tpc-ds
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Add msbuild to PATH
+        if: matrix.os == 'windows-latest'
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install poetry
+        run: pip install poetry
+      - name: Create poetry environment
+        run: poetry install
+      - name: Run integration test
+        run: poetry run datalogistik -d ${{ matrix.dataset }} -f parquet

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 __pycache__
 *datalogistik_cache*
 datalogistik/dbgen_tool
+datalogistik/dsdgen_tool
 .DS_Store

--- a/datalogistik/tpc_builders.py
+++ b/datalogistik/tpc_builders.py
@@ -246,7 +246,9 @@ class DSDGen(_TPCBuilder):
         log.info("Upgrading the solution file; this could take a few minutes...")
         solution_file = self.repo_build_path / "dbgen2.sln"
 
-        # Remove unnecessary projects from this file
+        # See https://github.com/gregrahn/tpcds-kit/blob/5a3a817/tools/dbgen2.sln
+        # Some of these projects (dsqgen, checksum, and grammar) don't upgrade nicely.
+        # We don't need them, so delete all references to them from this file.
         with open(solution_file, "r") as f:
             new_solution = "".join(
                 line
@@ -258,7 +260,7 @@ class DSDGen(_TPCBuilder):
             new_solution = new_solution.replace("EndProject\nEndProject", "EndProject")
             new_solution = new_solution.replace("EndProject\nEndProject", "EndProject")
         with open(solution_file, "w") as f:
-            f.writelines(new_solution)
+            f.write(new_solution)
 
         devenv = _run("vswhere", "-property", "productPath")
         _run(devenv, solution_file, "/upgrade")

--- a/datalogistik/tpc_builders.py
+++ b/datalogistik/tpc_builders.py
@@ -23,7 +23,7 @@ from typing import List, Optional
 from .log import log
 from .tpc_info import tpc_table_names
 
-repo_root = pathlib.Path(__file__).parent.resolve()
+local_package_root = pathlib.Path(__file__).parent.resolve()
 
 
 def _run(*args, **kwargs) -> str:
@@ -68,10 +68,13 @@ class _TPCBuilder(abc.ABC):
     executable_path: Optional[pathlib.Path] = None
     system: str = None
 
+    # details about the generator
     force_flag: str
     scale_flag: str
     file_extension: str
     table_names: List[str]
+
+    # details about the repo to clone if necessary
     repo_uri: str
     repo_commit: str
     repo_local_path: pathlib.Path
@@ -172,8 +175,8 @@ class DBGen(_TPCBuilder):
     table_names = tpc_table_names["tpc-h"]
     repo_uri = "https://github.com/electrum/tpch-dbgen.git"
     repo_commit = "32f1c1b92d1664dba542e927d23d86ffa57aa253"
-    repo_local_path = repo_root / "dbgen_tool"
-    repo_build_path = repo_root / "dbgen_tool"
+    repo_local_path = local_package_root / "dbgen_tool"
+    repo_build_path = local_package_root / "dbgen_tool"
 
     def _get_default_executable_path(self):
         """Return the executable path for this generator if one isn't given."""
@@ -221,8 +224,8 @@ class DSDGen(_TPCBuilder):
     table_names = tpc_table_names["tpc-ds"]
     repo_uri = "https://github.com/gregrahn/tpcds-kit.git"
     repo_commit = "5a3a81796992b725c2a8b216767e142609966752"
-    repo_local_path = repo_root / "dsdgen_tool"
-    repo_build_path = repo_root / "dsdgen_tool" / "tools"
+    repo_local_path = local_package_root / "dsdgen_tool"
+    repo_build_path = local_package_root / "dsdgen_tool" / "tools"
 
     def _get_default_executable_path(self):
         """Return the executable path for this generator if one isn't given."""


### PR DESCRIPTION
This PR adds support for building the `dsdgen` TPC-DS generator from scratch if a user doesn't have it. It will clone the tool from https://github.com/gregrahn/tpcds-kit/.

The code for cloning/making the tool is really similar to the TPC-H code, so in this PR I shoved a lot of that code back into the parent `_TPCBuilder` class. This makes the diff kinda hard to read; I'd recommend just reading the new `tpc_builders.py` file.

The PR also moves the TPC integration tests outside of the "test different methods of installation" checks so that those run faster and we're using less compute during the build.

Fixes #3 .