### PR TITLE
13 solidify cache hierarchy level names

### DIFF
--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -70,7 +70,7 @@ def main():
             other_format_path = pathlib.Path(
                 local_cache_location,
                 argument_info.dataset,
-                argument_info.scale_factor,
+                f"scalefactor_{argument_info.scale_factor}",
                 cached_file_format,
             )
             if other_format_path.exists():

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -84,6 +84,7 @@ def main():
                 ]
                 for cached_nrows in subfolders:
                     other_nrows_path = pathlib.Path(other_format_path, cached_nrows)
+                    cached_nrows = cached_nrows.split("_")[-1]
                     cached_dataset_metadata_file = pathlib.Path(
                         other_nrows_path, config.metadata_filename
                     )

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -47,8 +47,7 @@ def main():
     # check if an existing dataset is still valid.
 
     log.debug(f"Checking local cache at {local_cache_location}")
-    cached_dataset_path = pathlib.Path(
-        local_cache_location,
+    cached_dataset_path = util.create_cached_dataset_path(
         argument_info.dataset,
         argument_info.scale_factor,
         argument_info.format,
@@ -97,7 +96,6 @@ def main():
                             f"Metadata file located at '{cached_dataset_metadata_file}'"
                         )
                         cached_dataset_path = util.convert_dataset(
-                            local_cache_location,
                             dataset_info,
                             argument_info.compression,
                             cached_file_format,
@@ -122,20 +120,15 @@ def main():
     log.info("Dataset not found in local cache.")
 
     if argument_info.dataset in tpc_info.tpc_datasets:
-        cached_dataset_path = util.generate_dataset(
-            dataset_info, argument_info, local_cache_location
-        )
+        cached_dataset_path = util.generate_dataset(dataset_info, argument_info)
     else:
-        cached_dataset_path = util.download_dataset(
-            dataset_info, argument_info, local_cache_location
-        )
+        cached_dataset_path = util.download_dataset(dataset_info, argument_info)
 
     # Convert to the requested format if necessary
     if (dataset_info["format"] != argument_info.format) or (
         dataset_info["partitioning-nrows"] != argument_info.partition_max_rows
     ):
         cached_dataset_path = util.convert_dataset(
-            local_cache_location,
             dataset_info,
             argument_info.compression,
             dataset_info["format"],

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -53,6 +53,8 @@ def file_visitor(written_file):
 # Construct a path to a dataset entry in the cache (possibly not existing yet)
 def create_cached_dataset_path(name, scale_factor, format, partitioning_nrows):
     local_cache_location = config.get_cache_location()
+    scale_factor = f"scalefactor_{scale_factor}" if scale_factor != "" else ""
+    partitioning_nrows = f"partitioning_{partitioning_nrows}"
     return pathlib.Path(
         local_cache_location, name, scale_factor, format, partitioning_nrows
     )

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -16,7 +16,6 @@ import datetime
 import json
 import os
 import pathlib
-import shutil
 import tempfile
 
 import pyarrow as pa
@@ -74,7 +73,8 @@ def test_write_metadata():
 
 # TODO: test parquet->csv, partitioning conversion
 def test_convert_dataset_csv_to_parquet():
-    path = pathlib.Path("./test_csv/csv/0/")
+    cache_root = config.get_cache_location()
+    path = pathlib.Path(cache_root, "test_csv/csv/partitioning_0/")
     test_filename = "convtest"
     test_csv_file = test_filename + ".csv"
     test_parquet_file = test_filename + ".parquet"
@@ -94,15 +94,9 @@ def test_convert_dataset_csv_to_parquet():
     written_table = csv.read_csv(test_csv_file_path)
     print(written_table.schema)
     assert written_table == orig_table
-    converted_path = util.convert_dataset(
-        ".", dataset_info, None, "csv", "parquet", 0, 0
-    )
+    converted_path = util.convert_dataset(dataset_info, None, "csv", "parquet", 0, 0)
     test_parquet_file_path = pathlib.Path(converted_path, test_parquet_file)
     converted_table = ds.dataset(test_parquet_file_path).to_table()
     print(converted_table.schema)
     assert converted_table == orig_table
-    (test_csv_file_path).unlink()
-    (test_parquet_file_path / "part-0.parquet").unlink()
-    (path / config.metadata_filename).unlink()
-    (converted_path / config.metadata_filename).unlink()
-    shutil.rmtree("./test_csv", ignore_errors=True)
+    util.prune_cache_entry("test_csv")


### PR DESCRIPTION
Resolves #13 
- Renames unpartitioned dataset files back to their original filenames instead of creating a directory with a `part-0.format` file
- Added prefixes to the cache directory structure