### PR TITLE
Added --link option to create a hardlink to the cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,7 @@ Usage::
         [-s SCALE_FACTOR] \
         [-g GENERATOR_PATH] \
         [-p PARTITION_MAX_ROWS] \
-        [-c COMPRESSION] \
-        [-b, --bypass-cache] \
-        [-m, --make-copy]
+        [-c COMPRESSION]
 
     datalogistik cache [-h] \
         [--clean] \
@@ -57,14 +55,6 @@ Usage::
 
 ``COMPRESSION``
     Internal compression (passed to parquet writer).
-
-``bypass-cache``
-    Do not store any copies of the dataset in the cache.
-
-``make-copy``
-    Instead of creating hard-links to the dataset instance in the cache,
-    make a full copy of the files to the output directory.
-    Useful if you want a read/write instance of a dataset.
 
 ``clean``
     Perform a clean-up of the cache, checking whether all of the subdirectories 

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,13 @@ Usage::
     datalogistik generate [-h] \
         -d DATASET \
         -f FORMAT \
+        [-o OUTPUT] \
         [-s SCALE_FACTOR] \
         [-g GENERATOR_PATH] \
         [-p PARTITION_MAX_ROWS] \
-        [-b, --bypass-cache]
+        [-c COMPRESSION] \
+        [-b, --bypass-cache] \
+        [-m, --make-copy]
 
     datalogistik cache [-h] \
         [--clean] \
@@ -35,6 +38,10 @@ Usage::
     repository has a different format, it will be converted. Supported formats:
     ``parquet``, ``csv``.
 
+``OUTPUT``
+    Path where the output should be placed. If not specified, output will be placed in
+    a folder in the current working directory, with the name of the dataset.
+
 ``SCALE_FACTOR``
     Scale factor for generating TPC data. Default 1.
 
@@ -48,8 +55,16 @@ Usage::
     Partition the dataset using this value as the maximum number of rows per partition.
     Default 0, which means no partitioning.
 
+``COMPRESSION``
+    Internal compression (passed to parquet writer).
+
 ``bypass-cache``
     Do not store any copies of the dataset in the cache.
+
+``make-copy``
+    Instead of creating hard-links to the dataset instance in the cache,
+    make a full copy of the files to the output directory.
+    Useful if you want a read/write instance of a dataset.
 
 ``clean``
     Perform a clean-up of the cache, checking whether all of the subdirectories 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,6 @@ Usage::
     datalogistik generate [-h] \
         -d DATASET \
         -f FORMAT \
-        [-o OUTPUT] \
         [-s SCALE_FACTOR] \
         [-g GENERATOR_PATH] \
         [-p PARTITION_MAX_ROWS] \
@@ -35,10 +34,6 @@ Usage::
     File format to instantiate the dataset in. If the original dataset specified in the
     repository has a different format, it will be converted. Supported formats:
     ``parquet``, ``csv``.
-
-``OUTPUT``
-    Path where the output should be placed. If not specified, output will be placed in
-    a folder in the current working directory, with the name of the dataset.
 
 ``SCALE_FACTOR``
     Scale factor for generating TPC data. Default 1.

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -108,19 +108,6 @@ Supported formats: Parquet, csv",
         default=0,
         help="Partition the dataset using this maximum number of rows per file",
     )
-    gen_parser.add_argument(
-        "-b",
-        "--bypass-cache",
-        action="store_true",
-        help="Do not store any copies of the dataset in the cache",
-    )
-    gen_parser.add_argument(
-        "-m",
-        "--make-copy",
-        action="store_true",
-        help="Create a copy of the dataset, instead of hard-linking the files.'"
-        " Useful if you wish to create a read/write instance.",
-    )
 
     return parser.parse_args()
 

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -72,6 +72,13 @@ def parse_args():
 Supported formats: Parquet, csv",
     )
     gen_parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=False,
+        help="Path where the output should be placed",
+    )
+    gen_parser.add_argument(
         "-c",
         "--compression",
         type=str,
@@ -106,6 +113,13 @@ Supported formats: Parquet, csv",
         "--bypass-cache",
         action="store_true",
         help="Do not store any copies of the dataset in the cache",
+    )
+    gen_parser.add_argument(
+        "-m",
+        "--make-copy",
+        action="store_true",
+        help="Create a copy of the dataset, instead of hard-linking the files.'"
+        " Useful if you wish to create a read/write instance.",
     )
 
     return parser.parse_args()

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -40,26 +40,6 @@ def main():
         f"Creating an instance of Dataset '{argument_info.dataset}' in "
         f"'{argument_info.format}' format..."
     )
-    if argument_info.output:
-        output_dir = pathlib.Path(argument_info.output)
-    else:
-        output_dir = pathlib.Path(argument_info.dataset)
-    if config.get_cache_location() in output_dir.parents:
-        msg = f"Error: output path '{output_dir}' is inside the cache. Exiting."
-        log.error(msg)
-        raise RuntimeError(msg)
-    if pathlib.Path(output_dir).exists():
-        try:
-            # if this does not raise an error, the dir is not empty
-            next(output_dir.iterdir())
-            msg = (
-                f"Error: output directory '{output_dir}' "
-                " already exists and is not empty. Exiting."
-            )
-            log.error(msg)
-            raise RuntimeError(msg)
-        except StopIteration:
-            pass
 
     log.debug(f"Checking local cache at {local_cache_location}")
     cached_dataset_path = util.create_cached_dataset_path(

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -14,7 +14,6 @@
 
 import os
 import pathlib
-import shutil
 import sys
 import time
 

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -92,9 +92,6 @@ def main():
                             "Found cached dataset in different format/partitioning at "
                             f"'{other_nrows_path}'"
                         )
-                        log.debug(
-                            f"Metadata file located at '{cached_dataset_metadata_file}'"
-                        )
                         cached_dataset_path = util.convert_dataset(
                             dataset_info,
                             argument_info.compression,

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -75,7 +75,7 @@ def main():
         log.debug(
             f"Found cached dataset metadata file at '{cached_dataset_metadata_file}'"
         )
-        util.copy_from_cache(cached_dataset_path, output_dir, argument_info.make_copy)
+        util.output_result(cached_dataset_path)
         finish()
     else:  # not found in cache, check if the cache has other formats of this dataset
         log.debug(
@@ -124,15 +124,7 @@ def main():
                             cached_nrows,
                             argument_info.partition_max_rows,
                         )
-                        util.copy_from_cache(
-                            cached_dataset_path,
-                            output_dir,
-                            argument_info.make_copy,
-                        )
-                        if argument_info.bypass_cache:
-                            log.info("Removing cache entry")
-                            shutil.rmtree(cached_dataset_path, ignore_errors=True)
-                            util.clean_cache_dir(cached_dataset_path)
+                        util.output_result(cached_dataset_path)
                         finish()
                     else:
                         log.info(
@@ -162,12 +154,7 @@ def main():
             argument_info.partition_max_rows,
         )
 
-    # Copy to the actual output location
-    util.copy_from_cache(cached_dataset_path, output_dir, argument_info.make_copy)
-    if argument_info.bypass_cache:
-        log.info("Removing cache entry")
-        shutil.rmtree(cached_dataset_path, ignore_errors=True)
-        util.clean_cache_dir(cached_dataset_path)
+    util.output_result(cached_dataset_path)
     finish()
 
 

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -614,17 +614,5 @@ def download_dataset(dataset_info, argument_info):
     return cached_dataset_path
 
 
-def copy_from_cache(cached_dataset_path, output_path, make_copy):
-    dest_path = pathlib.Path(output_path)
-    shutil.rmtree(dest_path, ignore_errors=True)
-    copy_start = time.perf_counter()
-    cached_dataset_path.mkdir(parents=True, exist_ok=True)
-    if make_copy:
-        log.info("Copying dataset from cache...")
-        shutil.copytree(cached_dataset_path, dest_path)
-    else:
-        log.info("Creating hard-link to dataset in cache...")
-        shutil.copytree(cached_dataset_path, dest_path, copy_function=os.link)
-    copy_time = time.perf_counter() - copy_start
-    log.info("Finished Copying.")
-    log.debug(f"copy took {copy_time:0.2f} s")
+def output_result(dataset_directory):
+    print(dataset_directory)

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -615,4 +615,24 @@ def download_dataset(dataset_info, argument_info):
 
 
 def output_result(dataset_directory):
-    print(dataset_directory)
+    output = {"path": str(dataset_directory)}
+    metadata_file = pathlib.Path(dataset_directory, config.metadata_filename)
+    if metadata_file.exists():
+        with open(metadata_file) as f:
+            metadata = json.load(f)
+            add_if_present(
+                [
+                    "name",
+                    "format",
+                    "partitioning-nrows",
+                    "scale-factor",
+                    "dim",
+                    "delim",
+                    "parquet-compression",
+                ],
+                metadata,
+                output,
+            )
+            output["files"] = [item["file_path"] for item in metadata["files"]]
+
+    print(json.dumps(output))

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -100,6 +100,7 @@ def test_validate():
 
     written_metadata["files"] = file_listing
     json_string = json.dumps(written_metadata)
+    os.chmod(metadata_file_path, 0o666)  # to allow writing
     with open(metadata_file_path, "w") as f:
         f.write(json_string)
     util.validate_cache(False)  # this should not delete the entry, only report


### PR DESCRIPTION
(

Instead of creating a full copy, this PR creates hard-links to the files in the cache to preserve diskspace. If users want a read/write instance, they can override this behavior by using flag `--make-copy`
TODO (see https://github.com/conbench/datalogistik/issues/45#issuecomment-1218070367):
- [x] Output the final dataset to something more descriptive than [f"./{name}"](https://github.com/conbench/datalogistik/blob/main/datalogistik/util.py#L504).
- [ ] Add all the disambiguation we have in the cache
- [x] (optional) Make it be configurable

)

This PR is being retargeted to keep all the datasets in the 'cache' (we might need to reconsider that name), and to return a path to the requested dataset to the user.