### PR TITLE
Add functionality to specify schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,12 +211,13 @@ In addition, entries can have the following optional properties:
     - type_name: Name of an Arrow datatype
     - arguments: either a dictionary of argument_name:value items, a list of values,
     or a single value.
-    Example::
+    Example:
+    .. code::
 
     {
-    "a": "string",
-    "b": {"type_name": "timestamp", "arguments": {"unit": "ms"}},
-    "c": {"type_name": "decimal", "arguments": [7, 3]}
+        "a": "string",
+        "b": {"type_name": "timestamp", "arguments": {"unit": "ms"}},
+        "c": {"type_name": "decimal", "arguments": [7, 3]}
     }
 
 ``header-line``

--- a/README.rst
+++ b/README.rst
@@ -213,9 +213,11 @@ In addition, entries can have the following optional properties:
     or a single value.
     Example::
 
-    {"a": "string",
+    {
+    "a": "string",
     "b": {"type_name": "timestamp", "arguments": {"unit": "ms"}},
-    "c": {"type_name": "decimal", "arguments": [7, 3]}}
+    "c": {"type_name": "decimal", "arguments": [7, 3]}
+    }
 
 ``header-line``
     Boolean denoting whether the first line of a CSV file contains the column names (default: false)

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ In addition, entries can have the following optional properties:
     - arguments: either a dictionary of argument_name:value items, a list of values,
     or a single value.
     Example:
-    .. code::
+.. code::
 
     {
         "a": "string",

--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,10 @@ In addition, entries can have the following optional properties:
     but that is not what is meant here.
 
 ``schema``
-    The schema of the tabular data in the file. This entry is currently ignored.
+    The schema of the tabular data in the file.
+
+``header-line``
+    Boolean denoting whether the first line of a CSV file contains the column names (default: false)
 
 Dataset output
 --------------

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,19 @@ In addition, entries can have the following optional properties:
 
 ``schema``
     The schema of the tabular data in the file.
+    The structure of a schema is a JSON string with key:value pairs for each column.
+    The key is the column name, and the value is either the name of an Arrow datatype
+    without any parameters, or a dictionary with the following properties:
+    - type_name: Name of an Arrow datatype
+    - arguments: either a dictionary of argument_name:value items, a list of values,
+    or a single value.
+    Example::
+
+    {
+      "a": "string",
+      "b": {"type_name": "timestamp", "arguments": {"unit": "ms"}},
+      "c": {"type_name": "decimal", "arguments": [7, 3]}
+    }
 
 ``header-line``
     Boolean denoting whether the first line of a CSV file contains the column names (default: false)

--- a/README.rst
+++ b/README.rst
@@ -213,11 +213,9 @@ In addition, entries can have the following optional properties:
     or a single value.
     Example::
 
-    {
-      "a": "string",
-      "b": {"type_name": "timestamp", "arguments": {"unit": "ms"}},
-      "c": {"type_name": "decimal", "arguments": [7, 3]}
-    }
+    {"a": "string",
+    "b": {"type_name": "timestamp", "arguments": {"unit": "ms"}},
+    "c": {"type_name": "decimal", "arguments": [7, 3]}}
 
 ``header-line``
     Boolean denoting whether the first line of a CSV file contains the column names (default: false)

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -399,9 +399,7 @@ def get_dataset(input_file, dataset_info, table_name=None):
         po = csv.ParseOptions()
         ro = csv.ReadOptions()
         co = csv.ConvertOptions()
-        # TODO: Should we autogenerate column names by default?
-        # Or add a property in the metadata about it?
-        # or allow a fall-back to read_csv in case schema detection fails?
+        # TODO: Should we fall-back to read_csv in case schema detection fails?
 
         if "delim" in dataset_info:
             po = csv.ParseOptions(delimiter=dataset_info["delim"])
@@ -436,7 +434,6 @@ def get_dataset(input_file, dataset_info, table_name=None):
                 has_header_line = dataset_info.get("header-line", False)
                 autogen_column_names = not has_header_line
 
-            log.debug(f"autogen_column_names = {autogen_column_names}")
             ro = csv.ReadOptions(
                 column_names=column_names,
                 autogenerate_column_names=autogen_column_names

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -389,9 +389,7 @@ def get_dataset(input_file, dataset_info, table_name=None):
                 for table_entry in dataset_info.get("tables"):
                     if table_name is None or table_entry["table"] == table_name:
                         schema = get_arrow_schema(table_entry["schema"])
-                        column_names = list(
-                            table_entry["schema"].keys()
-                        )  # TODO: does this really always preserve ordering?
+                        column_names = list(table_entry["schema"].keys())
                         break
                 ro = csv.ReadOptions(column_names=column_names)
 

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -356,8 +356,11 @@ def get_dataset(input_file, dataset_info, table_name=None):
     if format == "csv":
         # defaults
         po = csv.ParseOptions()
-        ro = csv.ReadOptions()  # autogenerate_column_names=True)
+        ro = csv.ReadOptions()
         co = csv.ConvertOptions()
+        # TODO: Should we autogenerate column names by default?
+        # Or add a property in the metadata about it?
+        # or allow a fall-back to read_csv in case schema detection fails?
 
         if "delim" in dataset_info:
             po = csv.ParseOptions(delimiter=dataset_info["delim"])
@@ -491,13 +494,6 @@ def convert_dataset(
                     "schema": schema_to_dict(dataset.schema),
                 }
             )
-
-            # TODO: The dataset API does a poor job at detecting the schema.
-            # Would be nice to be able to fall back to read/write_csv etc.
-            # Another option is to store the schema as metadata in the repo and pass it
-            # to dataset.
-            # It would also be nice to detect/provide option whether the first line
-            # contains column names.
 
         conv_time = time.perf_counter() - conv_start
         log.info("Finished conversion.")

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -488,7 +488,10 @@ def convert_dataset(
                 if parquet_compression is None:
                     parquet_compression = "snappy"  # Use snappy by default
                 write_options = dataset_write_format.make_write_options(
-                    compression=parquet_compression
+                    compression=parquet_compression,
+                    use_deprecated_int96_timestamps=False,
+                    coerce_timestamps="us",
+                    allow_truncated_timestamps=True,
                 )
             if new_format == "csv":
                 dataset_write_format = ds.CsvFileFormat()

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -349,7 +349,6 @@ def arrow_type_from_json(input_type):
     if isinstance(args, Mapping):
         return arrow_type_function_lookup(type_name)(**args)
     elif isinstance(args, list):
-        log.debug(f"args {args}")
         return arrow_type_function_lookup(type_name)(*args)
     else:  # args is probably a single value
         return arrow_type_function_lookup(type_name)(args)

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -584,7 +584,7 @@ def download_dataset(dataset_info, argument_info):
     # so something could have gone wrong while downloading/converting previously
     if dataset_file_path.exists():
         log.debug(f"Removing existing file '{dataset_file_path}'")
-        dataset_file_path.rmdir()
+        dataset_file_path.unlink()
     url = dataset_info["url"]
     try:
         http = urllib3.PoolManager()

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -492,6 +492,11 @@ def convert_dataset(
                 )
             if new_format == "csv":
                 dataset_write_format = ds.CsvFileFormat()
+                # Don't include header if there's a known schema
+                if dataset_info.get("tables"):
+                    write_options = dataset_write_format.make_write_options(
+                        include_header=False
+                    )
 
             ds.write_dataset(
                 scanner,
@@ -526,7 +531,9 @@ def convert_dataset(
         log.debug(f"conversion took {conv_time:0.2f} s")
         # Parquet already stores the schema internally
         if new_format == "csv":
-            dataset_info["tables"] = metadata_table_list
+            # Don't overwrite schema if it is already known
+            if dataset_info.get("tables") is None:
+                dataset_info["tables"] = metadata_table_list
         dataset_info["format"] = new_format
         dataset_info["partitioning-nrows"] = new_nrows
         if parquet_compression is not None:

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -378,7 +378,7 @@ def get_table_schema_from_metadata(dataset_info, table_name):
             if table_name is None or table_entry["table"] == table_name:
                 if table_entry.get("schema"):
                     return table_entry["schema"]
-                break # there should be only 1
+                break  # there should be only 1
     return None
 
 
@@ -432,7 +432,7 @@ def get_dataset(input_file, dataset_info, table_name=None):
 
             ro = csv.ReadOptions(
                 column_names=column_names,
-                autogenerate_column_names=autogen_column_names
+                autogenerate_column_names=autogen_column_names,
             )
 
         dataset_read_format = ds.CsvFileFormat(
@@ -510,7 +510,10 @@ def convert_dataset(
             if new_format == "csv":
                 dataset_write_format = ds.CsvFileFormat()
                 # Don't include header if there's a known schema
-                if old_format == "csv" and (get_table_schema_from_metadata(dataset_info, file_name) or not dataset_info.get("header-line")):
+                if old_format == "csv" and (
+                    get_table_schema_from_metadata(dataset_info, file_name)
+                    or not dataset_info.get("header-line")
+                ):
                     write_options = dataset_write_format.make_write_options(
                         include_header=False
                     )

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -505,7 +505,7 @@ def convert_dataset(
         log.info("Finished conversion.")
         log.debug(f"conversion took {conv_time:0.2f} s")
         # Parquet already stores the schema internally
-        if new_format == csv:
+        if new_format == "csv":
             dataset_info["tables"] = metadata_table_list
         dataset_info["format"] = new_format
         dataset_info["partitioning-nrows"] = new_nrows

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -223,13 +223,14 @@ def valid_metadata_in_parent_dirs(dirpath):
     while walking_path != cache_root:
         if contains_dataset(walking_path):
             return True
+        walking_path = walking_path.parent
     return False
 
 
 # Performs cleanup if something happens while creating an entry in the cache
 def clean_cache_dir(path):
     path = pathlib.Path(path)
-    log.debug(f"Cleaning incomplete cache entry '{path}'")
+    log.debug(f"Cleaning cache directory '{path}'")
     cache_root = config.get_cache_location()
     if cache_root not in path.parents:
         msg = "Refusing to clean a directory outside of the local cache"

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -326,7 +326,10 @@ def arrow_type_from_json(input_type):
         log.error(msg)
         raise ValueError(msg)
 
-    return arrow_type_function_lookup(type_name)(**kwargs)
+    if kwargs is not None:
+        return arrow_type_function_lookup(type_name)(**kwargs)
+    else:
+        return arrow_type_function_lookup(type_name)()
 
 
 # Convert the given dict to a pyarrow.schema

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -297,11 +297,7 @@ def convert_arrow_alias(type_name):
         "double": "float64",
         "decimal": "decimal128",
     }
-    for (alias, func_name) in aliases.items():
-        if type_name == alias:
-            return func_name
-    # no alias was found
-    return type_name
+    return aliases.get(type_name, type_name)
 
 
 # Create an instance of the pyarrow datatype with the given name
@@ -361,9 +357,9 @@ def arrow_type_from_json(input_type):
 
 # Convert the given dict to a pyarrow.schema
 def get_arrow_schema(input_schema):
-    log.debug("Converting schema to pyarrow.schema...")
     if input_schema is None:
         return None
+    log.debug("Converting schema to pyarrow.schema...")
     field_list = []
     # TODO: a `field()` entry is not a (name, type) tuple
     for (field_name, type) in input_schema.items():

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -288,19 +288,13 @@ def schema_to_dict(schema):
 # Convert the given dict to a pyarrow.schema
 def get_arrow_schema(input_schema):
     log.debug("Converting schema to pyarrow.schema...")
-    arrow_type_functions = {
-        "string": pa.string,
-        "int32": pa.int32,
-        "int64": pa.int64,
-        "float32": pa.float32,
-        "float64": pa.float64,
-    }
     if input_schema is None:
         return None
     field_list = []
     for (field_name, type) in input_schema.items():
         log.debug(f"Schema: adding field {field_name}")
-        field_list.append(pa.field(field_name, arrow_type_functions[type]()))
+        pa_func = getattr(pa, type)  # Look-up the function to create this type
+        field_list.append(pa.field(field_name, pa_func()))
     return pa.schema(field_list)
 
 

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -343,10 +343,7 @@ def get_dataset(input_file, dataset_info, table_name=None):
             if dataset_info.get("tables"):
                 log.debug("Found schema information in metadata")
                 for table_entry in dataset_info.get("tables"):
-                    if (
-                        table_name is None
-                        or table_entry["table"] == f"{table_name}.{format}"
-                    ):
+                    if table_name is None or table_entry["table"] == table_name:
                         schema = get_arrow_schema(table_entry["schema"])
                         column_names = list(
                             table_entry["schema"].keys()
@@ -449,7 +446,7 @@ def convert_dataset(
 
             metadata_table_list.append(
                 {
-                    "table": f"{file_name}.{new_format}",
+                    "table": file_name,
                     "schema": schema_to_dict(dataset.schema),
                 }
             )
@@ -516,7 +513,7 @@ def generate_dataset(dataset_info, argument_info):
                     dataset, scanner = get_dataset(input_file, dataset_info, table)
                     metadata_table_list.append(
                         {
-                            "table": table + ".csv",
+                            "table": table,
                             "schema": schema_to_dict(dataset.schema),
                         }
                     )
@@ -618,7 +615,7 @@ def download_dataset(dataset_info, argument_info):
                 dataset, scanner = get_dataset(dataset_file_path, dataset_info)
                 dataset_info["tables"] = [
                     {
-                        "table": str(dataset_file_name),
+                        "table": str(pathlib.Path(dataset_file_name).stem),
                         "schema": schema_to_dict(dataset.schema),
                     }
                 ]

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -57,7 +57,7 @@ def file_visitor(written_file):
 # Construct a path to a dataset entry in the cache (possibly not existing yet)
 def create_cached_dataset_path(name, scale_factor, format, partitioning_nrows):
     local_cache_location = config.get_cache_location()
-    scale_factor = f"scalefactor_{scale_factor}" if scale_factor != "" else ""
+    scale_factor = f"scalefactor_{scale_factor}" if scale_factor else ""
     partitioning_nrows = f"partitioning_{partitioning_nrows}"
     return pathlib.Path(
         local_cache_location, name, scale_factor, format, partitioning_nrows

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -285,6 +285,14 @@ def schema_to_dict(schema):
     return field_dict
 
 
+# Convert a given item (string or dict) to the corresponding Arrow datatype
+def arrow_type_from_json(input_type):
+    if isinstance(input_type, str):
+        # Look-up the function to create this type
+        pa_type_func = getattr(pa, input_type)
+        return pa_type_func()
+
+
 # Convert the given dict to a pyarrow.schema
 def get_arrow_schema(input_schema):
     log.debug("Converting schema to pyarrow.schema...")
@@ -293,8 +301,8 @@ def get_arrow_schema(input_schema):
     field_list = []
     for (field_name, type) in input_schema.items():
         log.debug(f"Schema: adding field {field_name}")
-        pa_func = getattr(pa, type)  # Look-up the function to create this type
-        field_list.append(pa.field(field_name, pa_func()))
+        arrow_type = arrow_type_from_json(type)
+        field_list.append(pa.field(field_name, arrow_type))
     return pa.schema(field_list)
 
 

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -297,8 +297,6 @@ def arrow_type_function_lookup(function_name):
 
 # Convert a given item (string or dict) to the corresponding Arrow datatype
 def arrow_type_from_json(input_type):
-    # Dict of all pyarrow types that take parameters to their possible parameters
-    # and whether they are optional
     arrow_nested_types = {
         "list_",
         "large_list",

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "distlib"
-version = "0.3.5"
+version = "0.3.6"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -79,15 +79,15 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.7.1"
+version = "3.8.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
-testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
@@ -104,7 +104,7 @@ pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "identify"
-version = "2.5.2"
+version = "2.5.3"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -161,7 +161,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*
 
 [[package]]
 name = "numpy"
-version = "1.23.1"
+version = "1.23.2"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -180,11 +180,11 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
@@ -236,7 +236,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyarrow"
-version = "7.0.0"
+version = "9.0.0"
 description = "Python library for Apache Arrow"
 category = "main"
 optional = false
@@ -327,7 +327,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.11"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -335,30 +335,30 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, 
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.16.2"
+version = "20.16.4"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-distlib = ">=0.3.1,<1"
-filelock = ">=3.2,<4"
-platformdirs = ">=2,<3"
+distlib = ">=0.3.5,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<3"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
+docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "48ed10df3a259397635cac12a0aac0e6c09c130b4938c405aa25c05efdcaf51c"
+content-hash = "0b61a8cf26b68afb6b7c3ad0a494b038950f1908a2c49bcb9ca82f1ea1bd50a6"
 
 [metadata.files]
 atomicwrites = []
@@ -366,31 +366,58 @@ attrs = []
 black = []
 cfgv = []
 click = []
-colorama = []
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
 distlib = []
 filelock = []
 flake8 = []
 identify = []
-iniconfig = []
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 isort = []
 mccabe = []
 mypy-extensions = []
 nodeenv = []
 numpy = []
-packaging = []
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
 pathspec = []
 platformdirs = []
-pluggy = []
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
 pre-commit = []
-py = []
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pyarrow = []
 pycodestyle = []
 pyflakes = []
-pyparsing = []
-pytest = []
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
 pyyaml = []
-toml = []
-tomli = []
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
 typing-extensions = []
 urllib3 = []
 virtualenv = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ include = ["repo.json"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pyarrow = "^7.0.0"
+pyarrow = "^9.0.0"
 urllib3 = "^1.26.9"
 
 [tool.poetry.dev-dependencies]

--- a/repo.json
+++ b/repo.json
@@ -7,7 +7,7 @@
     "dim" : [22180168, 31],
     "format" : "csv",
     "file-compression" : "gz",
-    "tables": [{"table" : "fanniemae_2016Q4.csv", "schema" : {
+    "tables": [{"table" : "2016Q4", "schema" : {
         "LOAN_ID" : "string",
         "ACT_PERIOD" : "string",
         "SERVICER" : "string",

--- a/repo.json
+++ b/repo.json
@@ -47,6 +47,7 @@
     "delim" : ",",
     "dim" : [14863778, 18],
     "format" : "csv",
+    "header-line": true,
     "file-compression" : "gz",
     "files": [{"file_path": "yellow_tripdata_2010-01.csv", "file_size": 2728058790, "md5": "ac3b683361a0b3b7519616c1d2fd7dec"}, {"file_path": "yellow_tripdata_2010-01.csv.gz", "file_size": 591876633, "md5": "22bd86bf54da91faf26fa8a243644a9f"}]
 }, {

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -59,6 +59,75 @@ expected_metadata = {
     ],
 }
 
+arrow_types_noargs = {
+    pa.null,
+    pa.bool_,
+    pa.int8,
+    pa.int16,
+    pa.int32,
+    pa.int64,
+    pa.uint8,
+    pa.uint16,
+    pa.uint32,
+    pa.uint64,
+    pa.float16,
+    pa.float32,
+    pa.float64,
+    pa.date32,
+    pa.date64,
+    pa.month_day_nano_interval,
+    pa.string,
+    pa.utf8,
+    pa.large_binary,
+    pa.large_string,
+    pa.large_utf8,
+}
+arrow_types_args = {
+    (pa.time32("ms"), """"name": "time32", "args": {"unit": ms}"""),
+    (pa.time64("us"), """"name": "time64", "args": {"unit": us}"""),
+    (pa.timestamp("us"), """"name": "timestamp", "args": {"unit": us}"""),
+    (pa.duration("us"), """"name": "binary", "args": {"unit": "us"}"""),
+    (pa.binary(10), """"name": "binary", "args": {"size": 10}"""),
+    (
+        pa.decimal128(7, 3),
+        """"name": "decimal", "args": {"precision": 7, "index": 3}""",
+    ),
+}
+# These 2 should be equivalent
+complete_schema_json = "{'a': 'null', 'b': 'bool', 'c': 'int8', 'd': 'int16', 'e': 'int32', 'f': 'int64', 'g': 'uint8', 'h': 'uint16', 'i': 'uint32', 'j': 'uint64', 'k': 'halffloat', 'l': 'float', 'm': 'double', 'n': 'date32[day]', 'o': 'date64[ms]', 'p': 'month_day_nano_interval', 'q': 'string', 'r': 'string', 's': 'large_binary', 't': 'large_string', 'u': 'large_string', 'v': 'time32[ms]', 'w': 'time64[us]', 'x': 'timestamp[s]', 'y': 'duration[ns]', 'z': 'fixed_size_binary[10]', 'argh': 'decimal128(7, 3)'}"
+complete_schema = pa.schema(
+    [
+        pa.field("a", pa.null()),
+        pa.field("b", pa.bool_()),
+        pa.field("c", pa.int8()),
+        pa.field("d", pa.int16()),
+        pa.field("e", pa.int32()),
+        pa.field("f", pa.int64()),
+        pa.field("g", pa.uint8()),
+        pa.field("h", pa.uint16()),
+        pa.field("i", pa.uint32()),
+        pa.field("j", pa.uint64()),
+        pa.field("k", pa.float16()),
+        pa.field("l", pa.float32()),
+        pa.field("m", pa.float64()),
+        pa.field("n", pa.date32()),
+        pa.field("o", pa.date64()),
+        pa.field("p", pa.month_day_nano_interval()),
+        pa.field("q", pa.string()),
+        pa.field("r", pa.utf8()),
+        pa.field("s", pa.large_binary()),
+        pa.field("t", pa.large_string()),
+        pa.field("u", pa.large_utf8()),
+        # types with arguments
+        pa.field("v", pa.time32("ms")),
+        pa.field("w", pa.time64("us")),
+        pa.field("x", pa.timestamp("s")),
+        pa.field("y", pa.duration("ns")),
+        pa.field("z", pa.binary(10)),
+        pa.field("argh", pa.decimal128(7, 3)),
+    ]
+)
+
 
 def create_test_dataset(path):
     with open(os.path.join(path, "tmpfile"), "w") as tmpfile:
@@ -172,34 +241,16 @@ def test_convert_dataset_parquet_to_csv():
 
 
 def test_arrow_type_function_lookup():
-    arrow_types_noargs = {
-        pa.null,
-        pa.bool_,
-        pa.int8,
-        pa.int16,
-        pa.int32,
-        pa.int64,
-        pa.uint8,
-        pa.uint16,
-        pa.uint32,
-        pa.uint64,
-        pa.float16,
-        pa.float32,
-        pa.float64,
-        pa.date32,
-        pa.date64,
-        pa.month_day_nano_interval,
-        pa.string,
-        pa.utf8,
-        pa.large_binary,
-        pa.large_string,
-        pa.large_utf8,
-    }
     for func in arrow_types_noargs:
         assert func == util.arrow_type_function_lookup(func.__name__)
 
 
-def test_parse_schema():
+def test_arrow_type_from_json():
+    for func in arrow_types_noargs:
+        assert func() == util.arrow_type_from_json(func.__name__)
+
+
+def test_get_arrow_schema():
     expected_arrow_schema = pa.schema(
         [
             ("a", pa.string()),
@@ -216,3 +267,7 @@ def test_parse_schema():
         }"""
     arrow_schema = util.get_arrow_schema(json.loads(json_schema))
     assert arrow_schema == expected_arrow_schema
+
+
+def test_schema_to_dict():
+    assert str(util.schema_to_dict(complete_schema)) == complete_schema_json

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -169,3 +169,22 @@ def test_convert_dataset_parquet_to_csv():
     print(converted_table.schema)
     assert converted_table == orig_table
     util.prune_cache_entry("test_parquet")
+
+
+def test_parse_schema():
+    expected_arrow_schema = pa.schema(
+        [
+            ("a", pa.string()),
+            ("b", pa.int64()),
+            ("c", pa.float64()),
+            ("d", pa.timestamp(unit="ms")),
+        ]
+    )
+    json_schema = """{
+        "a" : "string",
+        "b" : "int64",
+        "c" : {"name": "float64"},
+        "d" : {"name": "timestamp", "arguments": {"unit": "ms"}}
+        }"""
+    arrow_schema = util.get_arrow_schema(json.loads(json_schema))
+    assert arrow_schema == expected_arrow_schema

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -171,6 +171,34 @@ def test_convert_dataset_parquet_to_csv():
     util.prune_cache_entry("test_parquet")
 
 
+def test_arrow_type_function_lookup():
+    arrow_types_noargs = {
+        pa.null,
+        pa.bool_,
+        pa.int8,
+        pa.int16,
+        pa.int32,
+        pa.int64,
+        pa.uint8,
+        pa.uint16,
+        pa.uint32,
+        pa.uint64,
+        pa.float16,
+        pa.float32,
+        pa.float64,
+        pa.date32,
+        pa.date64,
+        pa.month_day_nano_interval,
+        pa.string,
+        pa.utf8,
+        pa.large_binary,
+        pa.large_string,
+        pa.large_utf8,
+    }
+    for func in arrow_types_noargs:
+        assert func == util.arrow_type_function_lookup(func.__name__)
+
+
 def test_parse_schema():
     expected_arrow_schema = pa.schema(
         [

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -141,7 +141,13 @@ complete_csv_schema_json_input = """{
     "w": {"type_name": "time64", "arguments": "us"},
     "x": {"type_name": "timestamp", "arguments": {"unit": "ms"}}
     }"""
-complete_csv_schema_json_output = "{'a': 'null', 'b': 'bool', 'c': 'int8', 'd': 'int16', 'e': 'int32', 'f': 'int64', 'g': 'uint8', 'h': 'uint16', 'i': 'uint32', 'j': 'uint64', 'l': 'float', 'm': 'double', 'n': 'date32[day]', 'o': 'date64[ms]', 'q': 'string', 'r': 'string', 't': 'large_string', 'u': 'large_string', 'v': 'time32[ms]', 'w': 'time64[us]', 'x': 'timestamp[ms]'}"
+complete_csv_schema_json_output = (
+    "{'a': 'null', 'b': 'bool', 'c': 'int8', 'd': 'int16', 'e': 'int32', 'f': 'int64', "
+    "'g': 'uint8', 'h': 'uint16', 'i': 'uint32', 'j': 'uint64', 'l': 'float', 'm': "
+    "'double', 'n': 'date32[day]', 'o': 'date64[ms]', 'q': 'string', 'r': 'string', "
+    "'t': 'large_string', 'u': 'large_string', 'v': 'time32[ms]', 'w': 'time64[us]', "
+    "'x': 'timestamp[ms]'}"
+)
 complete_csv_schema = pa.schema(
     [
         pa.field("a", pa.null()),

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -482,9 +482,6 @@ def test_convert_dataset_parquet_partitioning():
     converted_path = util.convert_dataset(
         complete_dataset_info, None, format, format, 0, 10
     )
-    # for p in range(9, -1, -1):
-    #     f = converted_path / file_name / f"part-{p}.csv"
-    #     f.rename(converted_path / file_name / f"part-{p+1}.csv")
     converted_file = converted_path / file_name
     converted_dataset, _ = util.get_dataset(converted_file, complete_dataset_info)
     converted_table = converted_dataset.to_table()

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -47,12 +47,12 @@ expected_metadata = {
     .strftime("%Y-%m-%dT%H:%M:%S%z"),
     "files": [
         {
-            "file_path": "tmpfile",
+            "file_path": "testfile",
             "file_size": 18,
             "md5": "891bcd3700619af5151bf95b836ff9b1",
         },
         {
-            "file_path": os.path.join("tmp2", "tmpfile2"),
+            "file_path": os.path.join("tmp2", "testfile2"),
             "file_size": 20,
             "md5": "0ccc9b1a435e7d40a91ac7dd04c67fe8",
         },
@@ -61,12 +61,12 @@ expected_metadata = {
 
 
 def create_test_dataset(path):
-    with open(os.path.join(path, "tmpfile"), "w") as tmpfile:
-        tmpfile.write("test file contents")
+    with open(os.path.join(path, "testfile"), "w") as testfile:
+        testfile.write("test file contents")
         path2 = os.path.join(path, "tmp2")
         os.mkdir(path2)
-        with open(os.path.join(path2, "tmpfile2"), "w") as tmpfile2:
-            tmpfile2.write("test file 2 contents")
+        with open(os.path.join(path2, "testfile2"), "w") as testfile2:
+            testfile2.write("test file 2 contents")
     util.write_metadata(dataset_info, path)
 
 

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -207,7 +207,10 @@ def generate_complete_schema_data(num_rows):
         ],
         "o": [
             datetime.datetime(
-                random.randint(1970, 2270), random.randint(1, 12), random.randint(1, 28)
+                random.randint(1970, 2270),
+                random.randint(1, 12),
+                random.randint(1, 28),
+                tzinfo=datetime.timezone.utc,
             ).timestamp()
             * 1000
             for _ in range(k)
@@ -297,19 +300,7 @@ def test_get_dataset_with_schema():
     dataset, _ = util.get_dataset(test_file, complete_dataset_info)
     read_table = dataset.to_table()
 
-    # Comparing parts of the table because pytest truncates the output
-    rows1 = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-    rows2 = ["o"]  # failing: date64 field
-    rows3 = ["l", "m", "n", "q", "r", "t", "u", "v", "w", "x"]
-    ref_table1 = ref_table.select(rows1)
-    read_table1 = read_table.select(rows1)
-    ref_table2 = ref_table.select(rows2)
-    read_table2 = read_table.select(rows2)
-    ref_table3 = ref_table.select(rows3)
-    read_table3 = read_table.select(rows3)
-    assert ref_table1 == read_table1
-    assert ref_table2 == read_table2
-    assert ref_table3 == read_table3
+    assert ref_table == read_table
     util.prune_cache_entry(name)
 
 

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -406,6 +406,7 @@ def test_convert_dataset_csv_to_parquet():
         "name": "test_csv",
         "url": "convtest.csv",
         "format": "csv",
+        "header-line": True,
         "partitioning-nrows": 0,
     }
     pydict = {"int": [1, 2], "str": ["a", "b"]}

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -454,6 +454,8 @@ def test_convert_dataset_csv_partitioning():
     reverted_file = reverted_path / file_name
     reverted_dataset, _ = util.get_dataset(reverted_file, complete_dataset_info)
     reverted_table = reverted_dataset.to_table()
+    reverted_table = reverted_table.sort_by("e")
+    converted_table = converted_table.sort_by("e")
     assert reverted_table == converted_table
     clean("test_complete_dataset")
 
@@ -494,5 +496,7 @@ def test_convert_dataset_parquet_partitioning():
     reverted_file = reverted_path / file_name
     reverted_dataset, _ = util.get_dataset(reverted_file, complete_dataset_info)
     reverted_table = reverted_dataset.to_table()
+    reverted_table = reverted_table.sort_by("e")
+    converted_table = converted_table.sort_by("e")
     assert reverted_table == converted_table
     clean("test_complete_dataset")


### PR DESCRIPTION
Instead of relying on pyarrow.dataset, we would like to be able to specify a schema in the repo file. This will help solve type problems in large files, because pyarrow.dataset only inspects the first 1MB of data to infer types of columns.