### PR TITLE
Add way to discriminate between compression standards in the cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,10 +267,6 @@ datalogistik_metadata.ini
 ``homepage``
     Location where more information about the origins of dataset can be found.
 
-``parquet-compression``
-    When the parquet format is used, what compression standard was used internally. Note
-    that this is different from file-compression.
-
 ``tables``
     A list of tables in the dataset, each with its own (set of) files. Each entry in the
     list has the following properties:

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Usage::
         [-s SCALE_FACTOR] \
         [-g GENERATOR_PATH] \
         [-p PARTITION_MAX_ROWS] \
+        [-c COMPRESSION] \
         [-b, --bypass-cache]
 
     datalogistik cache [-h] \
@@ -47,6 +48,11 @@ Usage::
 ``PARTITION_MAX_ROWS``
     Partition the dataset using this value as the maximum number of rows per partition.
     Default 0, which means no partitioning.
+
+``COMPRESSION``
+    Compression to be used for the dataset. For Parquet dataset, this value will be
+    passed to the parquet writer.
+    For CSV datasets, supported values are gz (for GZip) or none.
 
 ``bypass-cache``
     Do not store any copies of the dataset in the cache.

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -75,7 +75,6 @@ Supported formats: Parquet, csv",
         "-c",
         "--compression",
         type=str,
-        default="snappy",
         help="Internal compression (passed to parquet writer)",
     )
     gen_parser.add_argument(
@@ -171,6 +170,11 @@ def parse_args_and_get_dataset_info():
                 msg = "Compression is only supported for parquet format"
                 log.error(msg)
                 raise ValueError(msg)
+        else:
+            if opts.format == "parquet":
+                # Set default here instead of in the CLI code so we can produce
+                # the error above
+                opts.compression = "snappy"
 
         if opts.scale_factor != "" and opts.dataset not in tpc_info.tpc_datasets:
             msg = "scale-factor is only supported for TPC datasets"

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -75,7 +75,8 @@ Supported formats: Parquet, csv",
         "-c",
         "--compression",
         type=str,
-        help="Internal compression (passed to parquet writer)",
+        help="Compression (for parquet: passed to parquet writer, "
+             "for csv: either None of gz)",
     )
     gen_parser.add_argument(
         "-s",
@@ -165,16 +166,19 @@ def parse_args_and_get_dataset_info():
             log.error(msg)
             raise ValueError(msg)
 
-        if opts.compression is not None:
-            if opts.format != "parquet":
-                msg = "Compression is only supported for parquet format"
-                log.error(msg)
-                raise ValueError(msg)
-        else:
+        # Defaults
+        if opts.compression is None:
             if opts.format == "parquet":
-                # Set default here instead of in the CLI code so we can produce
-                # the error above
                 opts.compression = "snappy"
+            if opts.format == "csv":
+                opts.compression = "gz"
+
+        # Note the difference between None and a string "None"
+        if (
+            opts.compression.lower() == "uncompressed"
+            or opts.compression.lower() == "none"
+        ):
+            opts.compression = None
 
         if opts.scale_factor != "" and opts.dataset not in tpc_info.tpc_datasets:
             msg = "scale-factor is only supported for TPC datasets"

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -75,6 +75,7 @@ Supported formats: Parquet, csv",
         "-c",
         "--compression",
         type=str,
+        default="snappy",
         help="Internal compression (passed to parquet writer)",
     )
     gen_parser.add_argument(

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -76,7 +76,7 @@ Supported formats: Parquet, csv",
         "--compression",
         type=str,
         help="Compression (for parquet: passed to parquet writer, "
-        "for csv: either None of gz)",
+        "for csv: either None or gz)",
     )
     gen_parser.add_argument(
         "-s",

--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -76,7 +76,7 @@ Supported formats: Parquet, csv",
         "--compression",
         type=str,
         help="Compression (for parquet: passed to parquet writer, "
-             "for csv: either None of gz)",
+        "for csv: either None of gz)",
     )
     gen_parser.add_argument(
         "-s",

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -131,7 +131,7 @@ def main():
     if argument_info.dataset in tpc_info.tpc_datasets:
         cached_dataset_path = util.generate_dataset(dataset_info, argument_info)
     else:
-        cached_dataset_path = util.download_dataset(dataset_info, argument_info)
+        cached_dataset_path = util.download_dataset(dataset_info)
 
     if dataset_info["format"] == "parquet":
         # retrieve the compression from the directory name

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -52,20 +52,17 @@ def main():
         argument_info.scale_factor,
         argument_info.format,
         str(argument_info.partition_max_rows),
+        argument_info.compression,
     )
     cached_dataset_metadata_file = pathlib.Path(
         cached_dataset_path, config.metadata_filename
     )
     if cached_dataset_metadata_file.exists():
-        log.debug(
-            f"Found cached dataset metadata file at '{cached_dataset_metadata_file}'"
-        )
+        log.debug(f"Found cached dataset at '{cached_dataset_path}'")
         util.copy_from_cache(cached_dataset_path, argument_info.dataset)
         finish()
     else:  # not found in cache, check if the cache has other formats of this dataset
-        log.debug(
-            f"No cached data metadata file found at '{cached_dataset_metadata_file}'"
-        )
+        log.debug("Requested dataset not found in cache")
         for cached_file_format in [x for x in config.supported_formats]:
             if argument_info.scale_factor:
                 scale_factor = f"scalefactor_{argument_info.scale_factor}"
@@ -80,46 +77,56 @@ def main():
             )
             if other_format_path.exists():
                 log.debug(
-                    "Found cached instance(s) with a different format/partitioning at "
+                    "Found cached instance(s) with a different format/compression/partitioning at "
                     f"'{other_format_path}'"
                 )
-                # Find a partitioning (any, really, we're going to convert it anyway)
-                subfolders = [
+                format_subfolders = [
                     f.name for f in os.scandir(other_format_path) if f.is_dir()
                 ]
-                for cached_nrows in subfolders:
-                    other_nrows_path = pathlib.Path(other_format_path, cached_nrows)
-                    cached_nrows = cached_nrows.split("_")[-1]
-                    cached_dataset_metadata_file = pathlib.Path(
-                        other_nrows_path, config.metadata_filename
+                # Grab the first subdir, we're going to convert it anyway
+                cached_nrows_dir = format_subfolders[0]
+                similar_dataset_path = other_format_path / cached_nrows_dir
+                cached_nrows = cached_nrows_dir.split("_")[-1]
+                if cached_file_format == "parquet":
+                    # In case of a parquet dataset, there is an additional level for compression type
+                    nrows_subfolders = [
+                        f.name for f in os.scandir(similar_dataset_path) if f.is_dir()
+                    ]
+                    cached_compression_dir = nrows_subfolders[0]
+                    similar_dataset_path = similar_dataset_path / cached_compression_dir
+                    cached_compression = cached_compression_dir.split("_")[-1]
+                else:
+                    cached_compression = None
+
+                cached_dataset_metadata_file = pathlib.Path(
+                    similar_dataset_path, config.metadata_filename
+                )
+                if cached_dataset_metadata_file.exists():
+                    log.debug(
+                        "Found cached dataset in different format/partitioning at "
+                        f"'{similar_dataset_path}'"
                     )
-                    if cached_dataset_metadata_file.exists():
-                        log.debug(
-                            "Found cached dataset in different format/partitioning at "
-                            f"'{other_nrows_path}'"
-                        )
-                        log.debug(
-                            f"Metadata file located at '{cached_dataset_metadata_file}'"
-                        )
-                        cached_dataset_path = util.convert_dataset(
-                            dataset_info,
-                            argument_info.compression,
-                            cached_file_format,
-                            argument_info.format,
-                            cached_nrows,
-                            argument_info.partition_max_rows,
-                        )
-                        util.copy_from_cache(cached_dataset_path, argument_info.dataset)
-                        if argument_info.bypass_cache:
-                            log.info("Removing cache entry")
-                            shutil.rmtree(cached_dataset_path, ignore_errors=True)
-                            util.clean_cache_dir(cached_dataset_path)
-                        finish()
-                    else:
-                        log.info(
-                            "Found cached dataset without metadata file, cleaning..."
-                        )
-                        util.clean_cache_dir(other_nrows_path)
+                    log.debug(
+                        f"Metadata file located at '{cached_dataset_metadata_file}'"
+                    )
+                    cached_dataset_path = util.convert_dataset(
+                        dataset_info,
+                        cached_compression,
+                        argument_info.compression,
+                        cached_file_format,
+                        argument_info.format,
+                        cached_nrows,
+                        argument_info.partition_max_rows,
+                    )
+                    util.copy_from_cache(cached_dataset_path, argument_info.dataset)
+                    if argument_info.bypass_cache:
+                        log.info("Removing cache entry")
+                        shutil.rmtree(cached_dataset_path, ignore_errors=True)
+                        util.clean_cache_dir(cached_dataset_path)
+                    finish()
+                else:
+                    log.info("Found cached dataset without metadata file, cleaning...")
+                    util.clean_cache_dir(similar_dataset_path)
 
     # If we have not exited at this point, nothing useable was found in the local cache.
     # We need to either generate or download the data.

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -137,7 +137,7 @@ def main():
         # retrieve the compression from the directory name
         compression = cached_dataset_path.parts[-1].split("_")[-1].lower()
     else:
-        compression = dataset_info["file-compression"]
+        compression = dataset_info.get("file-compression")
     # Convert if necessary
     if (dataset_info["format"] != argument_info.format) or (
         dataset_info["partitioning-nrows"] != argument_info.partition_max_rows

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -137,12 +137,19 @@ def main():
     else:
         cached_dataset_path = util.download_dataset(dataset_info, argument_info)
 
-    # Convert to the requested format if necessary
+    if dataset_info["format"] == "parquet":
+        # retrieve the compression from the directory name
+        pq_compression = cached_dataset_path.parts[-1].split("_")[-1].lower()
+    else:
+        pq_compression = None
+    # Convert if necessary
     if (dataset_info["format"] != argument_info.format) or (
         dataset_info["partitioning-nrows"] != argument_info.partition_max_rows
+        or (pq_compression != argument_info.compression)
     ):
         cached_dataset_path = util.convert_dataset(
             dataset_info,
+            pq_compression,
             argument_info.compression,
             dataset_info["format"],
             argument_info.format,

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -52,9 +52,7 @@ def main():
         cached_dataset_path, config.metadata_filename
     )
     if cached_dataset_metadata_file.exists():
-        log.debug(
-            f"Found cached dataset at '{cached_dataset_metadata_file}'"
-        )
+        log.debug(f"Found cached dataset at '{cached_dataset_metadata_file}'")
         util.output_result(cached_dataset_path)
         finish()
     else:  # not found in cache, check if the cache has other formats of this dataset
@@ -110,9 +108,7 @@ def main():
                     util.output_result(cached_dataset_path)
                     finish()
                 else:
-                    log.info(
-                        "Found cached dataset without metadata file, cleaning..."
-                    )
+                    log.info("Found cached dataset without metadata file, cleaning...")
                     util.clean_cache_dir(similar_dataset_path)
 
     # If we have not exited at this point, nothing useable was found in the local cache.

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -86,7 +86,7 @@ def main():
                 # Grab the first subdir, we're going to convert it anyway
                 cached_nrows_dir = format_subfolders[0]
                 similar_dataset_path = other_format_path / cached_nrows_dir
-                cached_nrows = cached_nrows_dir.split("_")[-1]
+                cached_nrows = int(cached_nrows_dir.split("_")[-1])
                 nrows_subfolders = [
                     f.name for f in os.scandir(similar_dataset_path) if f.is_dir()
                 ]

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -77,7 +77,7 @@ def main():
             )
             if other_format_path.exists():
                 log.debug(
-                    "Found cached instance(s) with a different format/compression/partitioning at "
+                    "Found cached instance(s) with a different format/partitioning/compression at "
                     f"'{other_format_path}'"
                 )
                 format_subfolders = [
@@ -87,23 +87,19 @@ def main():
                 cached_nrows_dir = format_subfolders[0]
                 similar_dataset_path = other_format_path / cached_nrows_dir
                 cached_nrows = cached_nrows_dir.split("_")[-1]
-                if cached_file_format == "parquet":
-                    # In case of a parquet dataset, there is an additional level for compression type
-                    nrows_subfolders = [
-                        f.name for f in os.scandir(similar_dataset_path) if f.is_dir()
-                    ]
-                    cached_compression_dir = nrows_subfolders[0]
-                    similar_dataset_path = similar_dataset_path / cached_compression_dir
-                    cached_compression = cached_compression_dir.split("_")[-1]
-                else:
-                    cached_compression = None
+                nrows_subfolders = [
+                    f.name for f in os.scandir(similar_dataset_path) if f.is_dir()
+                ]
+                cached_compression_dir = nrows_subfolders[0]
+                similar_dataset_path = similar_dataset_path / cached_compression_dir
+                cached_compression = cached_compression_dir.split("_")[-1]
 
                 cached_dataset_metadata_file = pathlib.Path(
                     similar_dataset_path, config.metadata_filename
                 )
                 if cached_dataset_metadata_file.exists():
                     log.debug(
-                        "Found cached dataset in different format/partitioning at "
+                        "Found cached dataset in different format/partitioning/compression at "
                         f"'{similar_dataset_path}'"
                     )
                     log.debug(
@@ -139,17 +135,17 @@ def main():
 
     if dataset_info["format"] == "parquet":
         # retrieve the compression from the directory name
-        pq_compression = cached_dataset_path.parts[-1].split("_")[-1].lower()
+        compression = cached_dataset_path.parts[-1].split("_")[-1].lower()
     else:
-        pq_compression = None
+        compression = dataset_info["file-compression"]
     # Convert if necessary
     if (dataset_info["format"] != argument_info.format) or (
         dataset_info["partitioning-nrows"] != argument_info.partition_max_rows
-        or (pq_compression != argument_info.compression)
+        or (compression != argument_info.compression)
     ):
         cached_dataset_path = util.convert_dataset(
             dataset_info,
-            pq_compression,
+            compression,
             argument_info.compression,
             dataset_info["format"],
             argument_info.format,

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -512,10 +512,10 @@ def convert_dataset(
             input_file = pathlib.Path(cached_dataset_path, f"{file_name}.{old_format}")
             output_file = pathlib.Path(output_dir, f"{file_name}.{new_format}")
             if (
-                    old_format == 'csv'
-                    and new_format == 'csv'
-                    and (old_nrows == new_nrows)
-                    and new_compression is None
+                old_format == "csv"
+                and new_format == "csv"
+                and (old_nrows == new_nrows)
+                and new_compression is None
             ):
                 input_file = input_file.parent / f"{input_file.name}.{old_compression}"
                 decompress(input_file, output_file, old_compression)
@@ -574,7 +574,9 @@ def convert_dataset(
                 }
             )
             if new_format == "csv" and new_compression:
-                compressed_output_file = output_file.parent / f"{output_file.name}.{new_compression}"
+                compressed_output_file = (
+                    output_file.parent / f"{output_file.name}.{new_compression}"
+                )
                 compress(output_file, compressed_output_file, new_compression)
                 output_file.unlink()
 
@@ -703,7 +705,9 @@ def download_dataset(dataset_info, argument_info):
     log.info("Downloading to cache...")
     down_start = time.perf_counter()
     if dataset_info["format"] == "parquet":
-        compression = "unknown" # Temporary location until we detect the actual compression
+        compression = (
+            "unknown"  # Temporary location until we detect the actual compression
+        )
     else:
         compression = dataset_info["file-compression"]
     cached_dataset_path = create_cached_dataset_path(

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -530,7 +530,7 @@ def convert_dataset(
         (dataset_info["format"] == new_format)
         and (dataset_info["partitioning-nrows"] == new_nrows)
         and (dataset_info.get("file-compression") == new_compression)  # rules out tpc
-        and (new_compression == "gz")  #  Only re-download compressed datasets
+        and (new_compression == "gz")  # Only re-download compressed datasets
     ):
         log.info("Re-downloading instead of converting.")
         return download_dataset(dataset_info)

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -59,9 +59,13 @@ def create_cached_dataset_path(
     local_cache_location = config.get_cache_location()
     if scale_factor:
         scale_factor = f"scalefactor_{scale_factor}"
+    else:
+        scale_factor = ""
     partitioning_nrows = f"partitioning_{partitioning_nrows}"
     if parquet_compression:
         parquet_compression = f"parquetcompression_{parquet_compression}"
+    else:
+        parquet_compression = ""
     if format == "parquet":
         return pathlib.Path(
             local_cache_location,

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -500,7 +500,7 @@ def convert_dataset(
         (dataset_info["format"] == new_format)
         and (dataset_info["partitioning-nrows"] == new_nrows)
         and (dataset_info.get("file-compression") == new_compression)  # rules out tpc
-        and (new_compression == "gz") #  Only re-download compressed datasets
+        and (new_compression == "gz")  #  Only re-download compressed datasets
     ):
         log.info("Re-downloading instead of converting.")
         return download_dataset(dataset_info)
@@ -676,8 +676,7 @@ def compress(uncompressed_file_path, output_dir, compression):
         return
     if compression == "gz":
         log.debug(
-            f"Compressing GZip dataset {uncompressed_file_path} into "
-            f"{output_dir}"
+            f"Compressing GZip dataset {uncompressed_file_path} into " f"{output_dir}"
         )
         if uncompressed_file_path.is_dir():
             file_list = []
@@ -688,7 +687,9 @@ def compress(uncompressed_file_path, output_dir, compression):
             file_list = [uncompressed_file_path]
         for uncompressed_file in file_list:
             with open(uncompressed_file, "rb") as input_file:
-                with gzip.open(output_dir / (uncompressed_file.name + ".gz"), "wb") as output_file:
+                with gzip.open(
+                    output_dir / (uncompressed_file.name + ".gz"), "wb"
+                ) as output_file:
                     shutil.copyfileobj(input_file, output_file)
     else:
         msg = f"Unsupported compression type ({compression})."
@@ -702,8 +703,7 @@ def decompress(compressed_file_path, output_dir, compression):
         return
     if compression == "gz":
         log.debug(
-            f"Decompressing GZip dataset {compressed_file_path} into "
-            f"{output_dir}"
+            f"Decompressing GZip dataset {compressed_file_path} into " f"{output_dir}"
         )
         if compressed_file_path.is_dir():
             file_list = []

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -701,7 +701,7 @@ def decompress(compressed_file_path, decompressed_file_path, compression):
         raise ValueError(msg)
 
 
-def download_dataset(dataset_info, argument_info):
+def download_dataset(dataset_info):
     log.info("Downloading to cache...")
     down_start = time.perf_counter()
     if dataset_info["format"] == "parquet":
@@ -711,7 +711,7 @@ def download_dataset(dataset_info, argument_info):
     else:
         compression = dataset_info["file-compression"]
     cached_dataset_path = create_cached_dataset_path(
-        argument_info.dataset,
+        dataset_info["name"],
         "",  # no scale_factor
         dataset_info["format"],
         str(dataset_info["partitioning-nrows"]),

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -358,6 +358,10 @@ def convert_dataset(
         f"Converting and caching dataset from {old_format}, {old_nrows} rows per "
         f"partition to {new_format}, {new_nrows} rows per partition..."
     )
+    if old_parquet_compression:
+        log.info(f"Converting from parquet compression: {old_parquet_compression}")
+    if new_parquet_compression:
+        log.info(f"Converting to parquet compression: {new_parquet_compression}")
     conv_start = time.perf_counter()
     dataset_name = dataset_info["name"]
     scale_factor = dataset_info.get("scale-factor", "")
@@ -380,7 +384,11 @@ def convert_dataset(
     with open(cached_dataset_metadata_file) as f:
         dataset_metadata = json.load(f)
 
-    if (dataset_metadata["format"] == new_format) and (old_nrows == new_nrows):
+    if (
+        (dataset_metadata["format"] == new_format)
+        and (old_nrows == new_nrows)
+        and (old_parquet_compression == new_parquet_compression)
+    ):
         log.info("Conversion not needed.")
         return cached_dataset_path
 

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -727,11 +727,11 @@ def download_dataset(dataset_info):
     log.info("Downloading to cache...")
     down_start = time.perf_counter()
     if dataset_info["format"] == "parquet":
-        compression = (
-            "unknown"  # Temporary location until we detect the actual compression
-        )
+        # Temporary location until we detect the actual compression
+        compression = "unknown"
     else:
-        compression = dataset_info["file-compression"]
+        compression = dataset_info.get("file-compression", "none")
+
     cached_dataset_path = create_cached_dataset_path(
         dataset_info["name"],
         "",  # no scale_factor

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -211,7 +211,6 @@ def write_metadata(dataset_info, path):
             "url",
             "homepage",
             "tables",
-            "parquet-compression",
             "files",
         ],
         dataset_info,
@@ -598,7 +597,6 @@ def convert_dataset(
                 dataset_info["tables"] = metadata_table_list
         dataset_info["format"] = new_format
         dataset_info["partitioning-nrows"] = new_nrows
-        dataset_info["parquet-compression"] = new_compression
         if dataset_info.get("files"):
             # Remove the old file listing, because it is not valid for the new dataset
             # (write_metadata will generate and add a new file listing with checksums)

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -518,7 +518,7 @@ def convert_dataset(
 
         for file_name in file_names:
             input_file = pathlib.Path(cached_dataset_path, f"{file_name}.{old_format}")
-            if old_compression:
+            if old_format != "parquet" and old_compression:
                 input_file = input_file.parent / f"{input_file.name}.{old_compression}"
             output_file = pathlib.Path(output_dir, f"{file_name}.{new_format}")
             if (

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -380,8 +380,6 @@ def convert_dataset(
             write_options = None  # Default
             if new_format == "parquet":
                 dataset_write_format = ds.ParquetFileFormat()
-                if parquet_compression is None:
-                    parquet_compression = "snappy"  # Use snappy by default
                 write_options = dataset_write_format.make_write_options(
                     compression=parquet_compression
                 )

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -57,15 +57,17 @@ def file_visitor(written_file):
 
 # Construct a path to a dataset entry in the cache (possibly not existing yet)
 def create_cached_dataset_path(
-    name, scale_factor, format, partitioning_nrows, parquet_compression
+    name, scale_factor, format, partitioning_nrows, parquet_compression=None
 ):
     local_cache_location = config.get_cache_location()
     scale_factor = f"scalefactor_{scale_factor}" if scale_factor else ""
     partitioning_nrows = f"partitioning_{partitioning_nrows}"
-    if parquet_compression:
-        parquet_compression = f"parquetcompression_{parquet_compression}"
-    else:
-        parquet_compression = ""
+    parquet_compression_str = ""
+    if format == "parquet":
+        if parquet_compression:
+            parquet_compression_str = f"parquetcompression_{parquet_compression}"
+        else:
+            parquet_compression_str = "parquetcompression_None"
     if format == "parquet":
         return pathlib.Path(
             local_cache_location,
@@ -73,7 +75,7 @@ def create_cached_dataset_path(
             scale_factor,
             format,
             partitioning_nrows,
-            parquet_compression,
+            parquet_compression_str,
         )
     return pathlib.Path(
         local_cache_location, name, scale_factor, format, partitioning_nrows

--- a/repo.json
+++ b/repo.json
@@ -49,7 +49,7 @@
     "format" : "csv",
     "header-line": true,
     "file-compression" : "gz",
-    "files": [{"file_path": "yellow_tripdata_2010-01.csv", "file_size": 2728058790, "md5": "ac3b683361a0b3b7519616c1d2fd7dec"}, {"file_path": "yellow_tripdata_2010-01.csv.gz", "file_size": 591876633, "md5": "22bd86bf54da91faf26fa8a243644a9f"}]
+    "files": [{"file_path": "yellow_tripdata_2010-01.csv.gz", "file_size": 591876633, "md5": "22bd86bf54da91faf26fa8a243644a9f"}]
 }, {
     "name" : "chi_traffic_2020_Q1",
     "url" : "https://ursa-qa.s3.amazonaws.com/chitraffic/chi_traffic_2020_Q1.parquet",

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -436,7 +436,9 @@ def test_convert_dataset_csv_to_parquet():
 def test_convert_dataset_parquet_to_csv():
     clean("test_parquet")
     cache_root = config.get_cache_location()
-    path = pathlib.Path(cache_root, "test_parquet/parquet/partitioning_0/compression_snappy")
+    path = pathlib.Path(
+        cache_root, "test_parquet/parquet/partitioning_0/compression_snappy"
+    )
     test_filename = "convtest"
     test_csv_file = test_filename + ".csv"
     test_parquet_file = test_filename + ".parquet"

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -436,7 +436,7 @@ def test_convert_dataset_csv_to_parquet():
 def test_convert_dataset_parquet_to_csv():
     clean("test_parquet")
     cache_root = config.get_cache_location()
-    path = pathlib.Path(cache_root, "test_parquet/parquet/partitioning_0/")
+    path = pathlib.Path(cache_root, "test_parquet/parquet/partitioning_0/parquetcompression_snappy")
     test_filename = "convtest"
     test_csv_file = test_filename + ".csv"
     test_parquet_file = test_filename + ".parquet"
@@ -457,7 +457,7 @@ def test_convert_dataset_parquet_to_csv():
     print(written_table.schema)
     assert written_table == orig_table
     converted_path = util.convert_dataset(
-        dataset_info, None, None, "parquet", "csv", 0, 0
+        dataset_info, "snappy", None, "parquet", "csv", 0, 0
     )
     test_csv_file_path = pathlib.Path(converted_path, test_csv_file)
     converted_table = ds.dataset(
@@ -497,7 +497,7 @@ def test_convert_dataset_csv_partitioning():
     written_table = dataset.to_table()
     assert written_table == orig_table
     converted_path = util.convert_dataset(
-        complete_dataset_info, None, format, format, 0, 10
+        complete_dataset_info, None, None, format, format, 0, 10
     )
     converted_file = converted_path / file_name
     converted_dataset, _ = util.get_dataset(converted_file, complete_dataset_info)
@@ -506,7 +506,7 @@ def test_convert_dataset_csv_partitioning():
     # Now convert it back to single partition
     clean(f"test_complete_dataset/{format}/partitioning_0")
     reverted_path = util.convert_dataset(
-        complete_dataset_info, None, format, format, 10, 0
+        complete_dataset_info, None, None, format, format, 10, 0
     )
     reverted_file = reverted_path / file_name
     reverted_dataset, _ = util.get_dataset(reverted_file, complete_dataset_info)
@@ -521,9 +521,10 @@ def test_convert_dataset_parquet_partitioning():
     num_rows = 100
     name = "test_complete_dataset"
     format = "parquet"
+    compression = "snappy"
     file_name = "complete_data." + format
     clean("test_complete_dataset")
-    path = util.create_cached_dataset_path(name, None, format, 0)
+    path = util.create_cached_dataset_path(name, None, format, 0, compression)
     path.mkdir(parents=True)
     test_file = path / file_name
     data = generate_complete_schema_data(num_rows, "parquet")
@@ -539,7 +540,7 @@ def test_convert_dataset_parquet_partitioning():
     written_table = dataset.to_table()
     assert written_table == orig_table
     converted_path = util.convert_dataset(
-        complete_dataset_info, None, format, format, 0, 10
+        complete_dataset_info, compression, compression, format, format, 0, 10
     )
     converted_file = converted_path / file_name
     converted_dataset, _ = util.get_dataset(converted_file, complete_dataset_info)
@@ -548,7 +549,7 @@ def test_convert_dataset_parquet_partitioning():
     # Now convert it back to single partition
     clean(f"test_complete_dataset/{format}/partitioning_0")
     reverted_path = util.convert_dataset(
-        complete_dataset_info, None, format, format, 10, 0
+        complete_dataset_info, compression, compression, format, format, 10, 0
     )
     reverted_file = reverted_path / file_name
     reverted_dataset, _ = util.get_dataset(reverted_file, complete_dataset_info)

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -334,7 +334,7 @@ def test_get_dataset_with_schema():
     num_rows = 10
     name = "test_complete_dataset"
     clean(name)
-    path = util.create_cached_dataset_path(name, None, "csv", 0)
+    path = util.create_cached_dataset_path(name, None, "csv", 0, None)
     path.mkdir(parents=True)
     test_file = path / "complete_data.csv"
     data = generate_complete_schema_data(num_rows, "csv")
@@ -402,7 +402,7 @@ def test_validate():
 def test_convert_dataset_csv_to_parquet():
     clean("test_csv")
     cache_root = config.get_cache_location()
-    path = pathlib.Path(cache_root, "test_csv/csv/partitioning_0/")
+    path = pathlib.Path(cache_root, "test_csv/csv/partitioning_0/compression_None")
     test_filename = "convtest"
     test_csv_file = test_filename + ".csv"
     test_parquet_file = test_filename + ".parquet"
@@ -436,7 +436,7 @@ def test_convert_dataset_csv_to_parquet():
 def test_convert_dataset_parquet_to_csv():
     clean("test_parquet")
     cache_root = config.get_cache_location()
-    path = pathlib.Path(cache_root, "test_parquet/parquet/partitioning_0/parquetcompression_snappy")
+    path = pathlib.Path(cache_root, "test_parquet/parquet/partitioning_0/compression_snappy")
     test_filename = "convtest"
     test_csv_file = test_filename + ".csv"
     test_parquet_file = test_filename + ".parquet"
@@ -474,7 +474,7 @@ def test_convert_dataset_csv_partitioning():
     format = "csv"
     file_name = "complete_data." + format
     clean("test_complete_dataset")
-    path = util.create_cached_dataset_path(name, None, format, 0)
+    path = util.create_cached_dataset_path(name, None, format, 0, None)
     path.mkdir(parents=True)
     test_file = path / file_name
     data = generate_complete_schema_data(num_rows, "csv")

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -131,7 +131,9 @@ def test_convert_dataset_csv_to_parquet():
     written_table = csv.read_csv(test_csv_file_path)
     print(written_table.schema)
     assert written_table == orig_table
-    converted_path = util.convert_dataset(dataset_info, None, "csv", "parquet", 0, 0)
+    converted_path = util.convert_dataset(
+        dataset_info, None, None, "csv", "parquet", 0, 0
+    )
     test_parquet_file_path = pathlib.Path(converted_path, test_parquet_file)
     converted_table = ds.dataset(test_parquet_file_path).to_table()
     print(converted_table.schema)
@@ -161,7 +163,9 @@ def test_convert_dataset_parquet_to_csv():
     written_table = pq.read_table(test_parquet_file_path)
     print(written_table.schema)
     assert written_table == orig_table
-    converted_path = util.convert_dataset(dataset_info, None, "parquet", "csv", 0, 0)
+    converted_path = util.convert_dataset(
+        dataset_info, None, None, "parquet", "csv", 0, 0
+    )
     test_csv_file_path = pathlib.Path(converted_path, test_csv_file)
     converted_table = ds.dataset(
         test_csv_file_path, format=ds.CsvFileFormat()

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -657,4 +657,3 @@ def test_convert_dataset_parquet_compression():
     converted_table = converted_table.sort_by("e")
     assert reverted_table == converted_table
     clean("test_complete_dataset")
-

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -487,6 +487,7 @@ def test_convert_dataset_csv_partitioning():
         "name": name,
         "url": "http://example.com/complete_data.csv",  # needed for filename during conversion
         "format": format,
+        "partitioning-nrows": 0,
         "tables": [
             {
                 "table": "complete_data",
@@ -536,6 +537,7 @@ def test_convert_dataset_parquet_partitioning():
         "name": name,
         "url": "http://example.com/complete_data.parquet",  # needed for filename during conversion
         "format": "parquet",
+        "partitioning-nrows": 0,
     }
     util.write_metadata(complete_dataset_info, path)
     dataset, _ = util.get_dataset(test_file, complete_dataset_info)


### PR DESCRIPTION
Fixes #9, fixes #16
This adds a directory hierarchy level, to denote what internal compression is used.
For downloaded parquet files, it first downloads to a directory `parquetcompression_unknown`, then detects the compression and moves it to the proper location in the cache.
- [x] Parquet
- [x] csv