### PR TITLE
Write JSON, not a string of escaped JSON

### DIFF
--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -79,7 +79,7 @@ Supported formats: Parquet, csv",
         "-s",
         "--scale-factor",
         type=str,
-        default="",
+        default=None,
         help="Scale factor for TPC datasets",
     )
     # TODO: should this be an env var instead of an argument?

--- a/datalogistik/config.py
+++ b/datalogistik/config.py
@@ -32,8 +32,6 @@ hashing_chunk_size = 16384
 
 
 def get_cache_location():
-    # TODO: Do we want to be able to specify the exact loction, or do we
-    # always want to add a directory here?
     return pathlib.Path(os.getenv("DATALOGISTIK_CACHE", default_cache_location))
 
 

--- a/datalogistik/dataset.py
+++ b/datalogistik/dataset.py
@@ -76,9 +76,6 @@ class Dataset:
     # To be filled in programmatically when a dataset is created
     local_creation_date: Optional[str] = None
 
-    # TODO: probably can be deleted
-    rel_path: Optional[pathlib.Path] = None
-
     # TODO: Post-init validation for things like delim if csv, etc.
 
     def __eq__(self, other):
@@ -379,7 +376,8 @@ class Dataset:
         if metadata_file_path.exists():
             util.set_readwrite(metadata_file_path)
         with open(metadata_file_path, "w") as metadata_file:
-            json.dump(obj=json_string, fp=metadata_file)
+            # TODO: how could we use json.dump(self, metadata_file) while still getting the custom serializer to_json() below?
+            metadata_file.write(json_string)
 
         util.set_readonly(metadata_file_path)
         pass
@@ -404,7 +402,6 @@ class Dataset:
 
         try:
             # ensure that we have a new dataset location
-            # TODO: make the hash something more random
             new_dataset.ensure_dataset_loc(new_hash=util.short_hash())
 
             # grab format output

--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -79,13 +79,6 @@ def file_visitor(written_file):
     log.debug(f"metadata={written_file.metadata}")
 
 
-# Construct a path to a dataset entry in the cache (possibly not existing yet)
-# TODO: delete me!
-def create_cached_dataset_path(name, hash):
-    local_cache_location = config.get_cache_location()
-    return pathlib.Path(local_cache_location, name, hash)
-
-
 # For each item in the itemlist, add it to metadata if it exists in dataset_info
 def add_if_present(itemlist, dataset_info, metadata):
     for item in itemlist:
@@ -397,7 +390,7 @@ def generate_dataset(dataset):
 
     try:
         generator_class = generators[dataset.name]
-        # TODO: suppoer executable_path as env var?
+        # TODO: support executable_path as env var?
         generator = generator_class(executable_path=None)
 
         dataset_path.mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ include = ["repo.json"]
 python = "^3.8"
 pyarrow = "^9.0.0"
 urllib3 = "^1.26.9"
+certifi = "^2022.6.15"
 
 [tool.poetry.dev-dependencies]
 black = "22.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ include = ["repo.json"]
 python = "^3.8"
 pyarrow = "^9.0.0"
 urllib3 = "^1.26.9"
-certifi = "^2022.6.15"
 
 [tool.poetry.dev-dependencies]
 black = "22.6.0"

--- a/tests/fixtures/test_cache/chi_taxi/dabb1e5/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/chi_taxi/dabb1e5/datalogistik_metadata.ini
@@ -4,7 +4,6 @@
     "format": "csv",
     "compression": "gzip",
     "scale-factor": "1",
-    "rel-path": "chi_traffic_sample.csv.gz",
     "tables": [
                 {
             "table": "taxi_2013",

--- a/tests/fixtures/test_cache/chi_traffic_sample/a1fa1fa/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/chi_traffic_sample/a1fa1fa/datalogistik_metadata.ini
@@ -2,7 +2,6 @@
     "local-creation-date": "2022-09-09T15:03:24-0500",
     "name": "chi_traffic_sample",
     "format": "parquet",
-    "rel-path": "chi_traffic_sample.parquet",
     "tables": [
         {
             "table": "chi_traffic_sample",

--- a/tests/fixtures/test_cache/chi_traffic_sample/babb1e5/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/chi_traffic_sample/babb1e5/datalogistik_metadata.ini
@@ -2,7 +2,6 @@
     "local-creation-date": "2022-09-09T15:03:24-0500",
     "name": "chi_traffic_sample",
     "format": "csv",
-    "rel-path": "chi_traffic_sample.csv",
     "tables": [
         {
             "table": "chi_traffic_sample",

--- a/tests/fixtures/test_cache/fanniemae_sample/a77e575/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/fanniemae_sample/a77e575/datalogistik_metadata.ini
@@ -3,7 +3,6 @@
     "name": "fanniemae_sample",
     "format": "csv",
     "scale-factor": "1",
-    "rel-path": "fanniemae_sample.csv",
     "tables": [
         {
             "table": "fanniemae_sample",

--- a/tests/fixtures/test_cache/nyctaxi_sample/ba11a57/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/nyctaxi_sample/ba11a57/datalogistik_metadata.ini
@@ -3,7 +3,6 @@
     "name": "nyctaxi_sample",
     "format": "csv",
     "scale-factor": "1",
-    "rel-path": "nyctaxi_sample.csv",
     "tables": [
         {
             "table": "nyctaxi_sample",

--- a/tests/fixtures/test_cache/taxi_2013/face7ed/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/taxi_2013/face7ed/datalogistik_metadata.ini
@@ -4,7 +4,6 @@
     "format": "csv",
     "delim": ",",
     "compression": "gzip",
-    "rel-path": "taxi_2013",
     "tables": [
         {
             "table": "taxi_2013",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -169,10 +169,15 @@ def test_write_metadata():
     penguins.ensure_dataset_loc("raw")
     penguins.write_metadata()
 
-    # now there is
-    assert pathlib.Path(
+    metadata_out = pathlib.Path(
         "tests/fixtures/test_cache/penguins/raw/", config.metadata_filename
-    ).exists()
+    )
+    # now there is
+    assert metadata_out.exists()
+
+    # and we can read it in!
+    read_dataset = Dataset.from_json(metadata_out)
+    assert read_dataset.name == "penguins"
 
     # cleanup all files that weren't there to start with
     for file in set(os.listdir(test_dir_path)) - set(start_files):


### PR DESCRIPTION
The biggest thing this does is fix a small issue where `write_metadata()` would write an escaped string as JSON, instead of taking the string and writing that directly.

I also updated the default scale_factor to` None` not `''`

I also cleaned up a number of TODOs that are already taken care of  