### PR TITLE
Add interface for getting metadata

### DIFF
--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -17,6 +17,7 @@ import sys
 
 from . import util
 from .dataset import Dataset
+from .dataset_search import find_exact_dataset
 from .log import log
 
 
@@ -28,6 +29,7 @@ def parse_args():
     sub_parsers = parser.add_subparsers(dest="command")
     cache_parser = sub_parsers.add_parser("cache")
     gen_parser = sub_parsers.add_parser("get")
+    meta_parser = sub_parsers.add_parser("metadata")
 
     cache_group = cache_parser.add_mutually_exclusive_group()
     cache_group.add_argument(
@@ -94,6 +96,36 @@ def parse_args():
         "for Windows on your PATH).",
     )
 
+    meta_parser.add_argument(
+        "-d",
+        "--dataset",
+        type=str,
+        required=True,
+        help="Name of the dataset",
+    )
+    meta_parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        required=True,
+        help="Format for the dataset. \
+Supported formats: Parquet, csv",
+    )
+    meta_parser.add_argument(
+        "-c",
+        "--compression",
+        type=str,
+        help="Compression (for parquet: passed to parquet writer, "
+        "for csv: either None or gz)",
+    )
+    meta_parser.add_argument(
+        "-s",
+        "--scale-factor",
+        type=str,
+        default=None,
+        help="Scale factor for TPC datasets",
+    )
+
     return parser.parse_args()
 
 
@@ -112,6 +144,26 @@ def handle_cache_command(cache_opts):
         raise RuntimeError(msg)
 
 
+def handle_metadata_command(opts):
+    dataset = Dataset(
+        name=opts.dataset,
+        format=opts.format,
+        scale_factor=opts.scale_factor,
+        compression=opts.compression,
+    )
+    # Get dataset if it already exists in the cache
+    exact_match = find_exact_dataset(dataset)
+
+    if exact_match:
+        with open(exact_match.metadata_file) as metadata_file:
+            print(metadata_file.read())
+    else:
+        log.info(
+            "Could not find a corresponding dataset in the cache. \n"
+            "Make sure this dataset is instantiated by running the 'get' command first."
+        )
+
+
 def parse_args_and_get_dataset_info():
     # Parse and check cmdline options
     opts = parse_args()
@@ -121,6 +173,10 @@ def parse_args_and_get_dataset_info():
 
     if opts.command == "cache":
         handle_cache_command(opts)
+        sys.exit(0)
+
+    elif opts.command == "metadata":
+        handle_metadata_command(opts)
         sys.exit(0)
 
     elif opts.command == "get":

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 from pyarrow import dataset as pyarrowdataset
 
-from datalogistik import config
+from datalogistik import config, datalogistik
 from datalogistik.dataset import Dataset
 from datalogistik.dataset_search import find_close_dataset, find_exact_dataset
 from datalogistik.table import Table
@@ -312,3 +312,25 @@ def test_get_dataset_with_schema():
     # TODO: can we alter the schema on the fly like this?
     # https://github.com/conbench/datalogistik/blob/027169a4194ba2eb27ff37889ad7e541bb4b4036/tests/test_datalogistik.py#L332-L358
     pass
+
+
+def test_metadata_command(capsys):
+    metadata_file = "./tests/fixtures/test_cache/chi_traffic_sample/a1fa1fa/datalogistik_metadata.ini"
+    with open(metadata_file) as f:
+        metadata = json.load(f)
+    with pytest.raises(SystemExit) as e:
+        sys.argv = [
+            "test_dataset",
+            "metadata",
+            "-d",
+            "chi_traffic_sample",
+            "-f",
+            "parquet",
+        ]
+        datalogistik.main()
+        assert e.type == SystemExit
+        assert e.value.code == 0
+
+    captured = capsys.readouterr().out
+    output = json.loads(captured)
+    assert output == metadata


### PR DESCRIPTION
Closes #54
Adds a `metadata` command that prints out all the metadata of a dataset instance in the cache. If it does not exist, it will _not_ instantiate it and produce an error.