### PR TITLE
Allow `compress` and `decompressed to uncompressed == "none" == None

### DIFF
--- a/datalogistik/util.py
+++ b/datalogistik/util.py
@@ -430,7 +430,11 @@ def generate_dataset(dataset):
 
 
 def compress(uncompressed_file_path, output_dir, compression):
-    if compression is None:
+    if (
+        compression is None
+        or compression.lower() == "none"
+        or compression == "uncompressed"
+    ):
         return
     if compression == "gz":
         log.debug(
@@ -457,7 +461,12 @@ def compress(uncompressed_file_path, output_dir, compression):
 
 
 def decompress(compressed_file_path, output_dir, compression):
-    if compression is None:
+    if (
+        compression is None
+        or compression is None
+        or compression.lower() == "none"
+        or compression == "uncompressed"
+    ):
         return
     if compression == "gz":
         log.debug(

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -20,6 +20,7 @@ import random
 import string
 
 import pyarrow as pa
+import pytest
 
 from datalogistik import __version__, util
 
@@ -322,3 +323,10 @@ def test_schema_to_dict():
     assert (
         str(util.schema_to_dict(complete_csv_schema)) == complete_csv_schema_json_output
     )
+
+
+@pytest.mark.parametrize("comp_string", [None, "none", "NoNe", "uncompressed"])
+def test_compress(comp_string):
+    # These should all not compress/decompress since they are "the same"
+    assert util.compress("uncompressed_file_path", "output_dir", comp_string) is None
+    assert util.decompress("uncompressed_file_path", "output_dir", comp_string) is None


### PR DESCRIPTION
Another small change, this for tor the compress|decompress functions to accept our various spellings of uncompressed.