### PR TITLE
Clean up a path bug + add tests for it

### DIFF
--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -31,6 +31,9 @@ def finish():
 
 
 def main(dataset=None):
+    # dataset here should typically be None, so then we use parse_args_and_get_dataset_info() to
+    # create the dataset to use. But it can be helpful in tests to construct ones own dataset
+    # with Dataset(name="my dataset", format="very_fancy") and pass it as the dataset argument
     if dataset is None:
         dataset = cli.parse_args_and_get_dataset_info()
 

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -30,7 +30,7 @@ def finish():
     sys.exit(0)
 
 
-def main(dataset):
+def main(dataset=cli.parse_args_and_get_dataset_info()):
     if config.get_max_cpu_count() != 0:
         pyarrow.set_cpu_count(config.get_max_cpu_count())
         pyarrow.set_io_thread_count(config.get_max_cpu_count())

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -30,9 +30,7 @@ def finish():
     sys.exit(0)
 
 
-def main():
-    dataset = cli.parse_args_and_get_dataset_info()
-
+def main(dataset):
     if config.get_max_cpu_count() != 0:
         pyarrow.set_cpu_count(config.get_max_cpu_count())
         pyarrow.set_io_thread_count(config.get_max_cpu_count())
@@ -58,4 +56,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(dataset=cli.parse_args_and_get_dataset_info())

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -30,7 +30,10 @@ def finish():
     sys.exit(0)
 
 
-def main(dataset=cli.parse_args_and_get_dataset_info()):
+def main(dataset=None):
+    if dataset is None:
+        dataset = cli.parse_args_and_get_dataset_info()
+
     if config.get_max_cpu_count() != 0:
         pyarrow.set_cpu_count(config.get_max_cpu_count())
         pyarrow.set_io_thread_count(config.get_max_cpu_count())
@@ -56,4 +59,4 @@ def main(dataset=cli.parse_args_and_get_dataset_info()):
 
 
 if __name__ == "__main__":
-    main(dataset=cli.parse_args_and_get_dataset_info())
+    main()

--- a/datalogistik/dataset.py
+++ b/datalogistik/dataset.py
@@ -480,9 +480,7 @@ class Dataset:
                     # Convert from name.format/part-0.format to simply a file name.format
                     # To stay consistent with downloaded/generated datasets (without partitioning)
                     # TODO: do we want to change this in accordance to tpc-raw?
-                    tmp_dir_name = pathlib.Path(
-                        output_file.parent, f"{output_file}.tmp"
-                    )
+                    tmp_dir_name = pathlib.Path(f"{output_file}.tmp")
                     os.rename(output_file, tmp_dir_name)
                     os.rename(
                         pathlib.Path(tmp_dir_name, f"part-0.{new_dataset.format}"),

--- a/tests/fixtures/test_cache/fanniemae_sample/a77e575/datalogistik_metadata.ini
+++ b/tests/fixtures/test_cache/fanniemae_sample/a77e575/datalogistik_metadata.ini
@@ -2,7 +2,7 @@
     "local-creation-date": "2022-09-09T15:03:24-0500",
     "name": "fanniemae_sample",
     "format": "csv",
-    "scale-factor": "1",
+    "delim": "|",
     "tables": [
         {
             "table": "fanniemae_sample",

--- a/tests/test_datalogistik.py
+++ b/tests/test_datalogistik.py
@@ -20,6 +20,7 @@ import pathlib
 import random
 import shutil
 import string
+import sys
 
 import pyarrow as pa
 import pytest
@@ -355,6 +356,7 @@ def test_main(capsys):
     assert isinstance(captured["tables"], dict)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="windows errors on the cleanup")
 def test_main_with_convert(capsys):
     # the directory penguins has data _as if_ it were downloaded from a repo for the purposes of testing metadata writing
     test_dir_path = "tests/fixtures/test_cache/fanniemae_sample"

--- a/tests/test_tpc.py
+++ b/tests/test_tpc.py
@@ -19,7 +19,7 @@ import tempfile
 
 import pytest
 
-from datalogistik import datalogistik, tpc_validation
+from datalogistik import cli, datalogistik, tpc_validation
 
 # TODO: TPC-DS tests & validation
 # TODO: add more unittest for testing more parameters (sf, partitions, format)
@@ -41,7 +41,7 @@ def test_validate_tpc_generation(capsys, dataset_name, format):
                 "-f",
                 format,
             ]
-            datalogistik.main()
+            datalogistik.main(dataset=cli.parse_args_and_get_dataset_info())
             assert e.type == SystemExit
             assert e.value.code == 0
 

--- a/tests/test_tpc.py
+++ b/tests/test_tpc.py
@@ -19,7 +19,7 @@ import tempfile
 
 import pytest
 
-from datalogistik import cli, datalogistik, tpc_validation
+from datalogistik import datalogistik, tpc_validation
 
 # TODO: TPC-DS tests & validation
 # TODO: add more unittest for testing more parameters (sf, partitions, format)

--- a/tests/test_tpc.py
+++ b/tests/test_tpc.py
@@ -41,7 +41,7 @@ def test_validate_tpc_generation(capsys, dataset_name, format):
                 "-f",
                 format,
             ]
-            datalogistik.main(dataset=cli.parse_args_and_get_dataset_info())
+            datalogistik.main()
             assert e.type == SystemExit
             assert e.value.code == 0
 


### PR DESCRIPTION
The copy-to-temp step had a small bug where it was repeating the path twice in some circumstances. This addresses that + adds two integration tests that confirm that at least one pass through these will succeed.