### PR TITLE
default to none compression

### DIFF
--- a/datalogistik/dataset.py
+++ b/datalogistik/dataset.py
@@ -83,6 +83,15 @@ class Dataset:
         if self.scale_factor is None and self.name in tpc_info.tpc_datasets:
             self.scale_factor = 1.0
 
+        # Use None as the true default for uncompressed
+        # the first comparisson is a bit redundant, but None.lower() fails
+        if (
+            self.compression is None
+            or self.compression.lower() == "none"
+            or self.compression.lower() == "uncompressed"
+        ):
+            self.compression = None
+
     def __eq__(self, other):
         if not isinstance(other, Dataset):
             return NotImplemented

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -207,6 +207,16 @@ def test_eq():
     assert ds1 == ds2
 
 
+def test_post_init():
+    # We get defautl scale_factor=1
+    ds = Dataset(name="tpc-h")
+    assert ds.scale_factor == 1
+
+    # uncompressed all uses None
+    ds = Dataset(name="posty", compression="uncompressed")
+    assert ds.compression is None
+
+
 def test_output_result():
     expected = json.dumps(
         {


### PR DESCRIPTION
This happens at the init stage for now so that CLI calls go from "uncompressed" -> None. 

In the future we might consider making this a bit less funky: using `None` meaningfully here is a bit odd compared to it being unspecified elsewhere... but the compression argument in pyarrow doesn't take `uncompressed` it takes `None`, so we would need to do a whole getter | setter thing for compression where we store "uncompressed" for all of them but then when we get it for writing we swap to `None`. Not sure if it's worth all of that, so let's kick that decision down the road.