### PR TITLE
Handle csv.gz extension, extra null strings, and download tiles to table names

### DIFF
--- a/datalogistik/cli.py
+++ b/datalogistik/cli.py
@@ -135,9 +135,9 @@ def parse_args_and_get_dataset_info():
         # TODO:
         #  * compression (in particular: test supported file-compression)
         #  * partitioning (later)
-        dataset_info = repo.search_repo(opts.dataset, repo.get_repo())
-        if dataset_info:
-            dataset.fill_in_defaults(dataset_info)
+        dataset_from_repo = repo.search_repo(opts.dataset, repo.get_repo())
+        if dataset_from_repo:
+            dataset.fill_in_defaults(dataset_from_repo)
         if dataset.compression is None and dataset.format == "parquet":
             dataset.compression = "snappy"
 

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -54,7 +54,6 @@ def main(dataset=None):
 
     # Convert if not
     close_match = dataset_search.find_or_instantiate_close_dataset(dataset)
-
     if close_match != dataset:
         new_dataset = close_match.convert(dataset)
     else:

--- a/datalogistik/datalogistik.py
+++ b/datalogistik/datalogistik.py
@@ -54,6 +54,7 @@ def main(dataset=None):
 
     # Convert if not
     close_match = dataset_search.find_or_instantiate_close_dataset(dataset)
+
     if close_match != dataset:
         new_dataset = close_match.convert(dataset)
     else:

--- a/repo.json
+++ b/repo.json
@@ -9,7 +9,11 @@
         "tables": [
             {
                 "table": "2016Q4",
-                "files": [{"file_path": "2016Q4.csv.gz"}],
+                "files": [
+                    {
+                        "file_path": "2016Q4.csv.gz"
+                    }
+                ],
                 "dim": [
                     22180168,
                     31
@@ -58,6 +62,9 @@
         "format": "csv",
         "header-line": true,
         "compression": "gz",
+        "extra_nulls": [
+            "*"
+        ],
         "tables": [
             {
                 "table": "nyctaxi_2010-01",


### PR DESCRIPTION
Sorry for the handful of different changes here, ran into these sequentially getting this to work with arrowbench.

* handles the .csv.gz suffix (this was the minimal possible way to support it, we might want to come back and make an extension helper method to help do that more categorically)
* adds an "extra_nulls" field to datasets that let us specify strings to treat as nulls.
  This is mostly needed for the nyctaxi csv which has a `*` in an otherwise numeric column. The odd thing is that `pyarrow.csv.read_csv()` handles this case _just fine_ but `pyarrow.dataset()` does not. I'm not totally sure we want to extend out the repo + datasets arguments quite like this in the long run, but given that everything can default to null I vote let's do this for now and see if it grows or becomes more of a problem.
* uses "gzip" internally, but accepts "gz" or "gzip"
* Ensures that a download gets saved as `{table_name}.{format}` instead of whatever it's stored as (this is most prominent in our current taxi dataset)
* A small renaming of a variable in the cli to make things extra extra clear what the dataset to fill defaults from is
* A bunch of additional tests for this functionality + some untested functionality around this 