### PR TITLE
Change file extension from .feather to .arrow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Usage::
 ``FORMAT``
     File format to instantiate the dataset in. If the original dataset specified in the
     repository has a different format, it will be converted. Supported formats:
-    ``parquet``, ``csv``, ``feather``.
+    ``parquet``, ``csv``, ``arrow``.
 
 ``SCALE_FACTOR``
     Scale factor for generating TPC data. Default 1.

--- a/datalogistik/config.py
+++ b/datalogistik/config.py
@@ -27,7 +27,7 @@ if platform.system() == "Windows":
 else:  # Unix (Linux or Mac)
     default_cache_location = os.path.join(os.getenv("HOME"), ".datalogistik_cache")
 metadata_filename = "datalogistik_metadata.ini"
-supported_formats = ["parquet", "csv", "feather", "tpc-raw"]
+supported_formats = ["parquet", "csv", "arrow", "tpc-raw"]
 hashing_chunk_size = 16384
 
 

--- a/datalogistik/dataset.py
+++ b/datalogistik/dataset.py
@@ -291,8 +291,8 @@ class Dataset:
         schema = None
         if self.format == "parquet":
             dataset_read_format = pads.ParquetFileFormat()
-        if self.format == "feather":
-            dataset_read_format = pads.IpcFileFormat()
+        if self.format == "arrow":
+            dataset_read_format = "arrow"
         if self.format == "csv":
             dataset_read_format, schema = self.get_csv_dataset_spec(table)
         if self.format == "tpc-raw":
@@ -420,7 +420,7 @@ class Dataset:
                 allow_truncated_timestamps=True,
             )
 
-        if self.format == "feather":
+        if self.format == "arrow":
             dataset_write_format = pads.IpcFileFormat()
             # Using pyarrow.datasets, compression is not supported
             write_options = dataset_write_format.make_write_options()
@@ -502,7 +502,7 @@ class Dataset:
                     f"metadata ({self.compression}, updating..."
                 )
                 self.compression = detected_compression
-        # There is no API for detecting feather's internal compression,
+        # There is no API for detecting Arrow IPC's internal compression,
         # so we need to rely on what the user specified in the repo file
 
         # TODO: add auto-detected csv schemas? I'm not actually sure this is a good idea, but this is how we did it:
@@ -544,8 +544,8 @@ class Dataset:
             f"compression {self.compression} to {new_dataset.format}, "
             f"compression {new_dataset.compression}..."
         )
-        if new_dataset.format == "feather" and new_dataset.compression:
-            msg = "Compression not supported when converting to Feather format."
+        if new_dataset.format == "arrow" and new_dataset.compression:
+            msg = "Compression not supported when converting to Arrow IPC format."
             log.error(msg)
             raise ValueError(msg)
 

--- a/datalogistik/dataset_search.py
+++ b/datalogistik/dataset_search.py
@@ -66,7 +66,7 @@ def find_or_instantiate_close_dataset(dataset):
     # when we support .arrow, those likely should be first, then parquet, et c.
     # TODO: sort by compression too?
     format_preference = {
-        "feather": 0,
+        "arrow": 0,
         "parquet": 1,
         "csv": 2,
         "tpc-raw": 3,


### PR DESCRIPTION
When Arrow 10.0 is release (we need this https://github.com/apache/arrow/pull/13677), we can use these changes to update the file extension of Arrow IPC files to .arrow.